### PR TITLE
Adding subunit-formatted output as an option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,6 +2,7 @@
 
 var config = require("./lib/cli").configure({
     port : 8000,
+    formatter : "console",
     argv : process.argv.splice(2)
 });
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -88,6 +88,8 @@ function fromConfiguration (config) {
         while (l--) ui.pending();
     }
 
+    var formatResult = ui.formatters[config.formatter];
+
     req.on("response", function (res, id) {
         ui.log("Waiting for results. When you're done, hit Ctrl-C to exit.");
         ui.debug("Batch registered:", id);
@@ -99,7 +101,7 @@ function fromConfiguration (config) {
 
             http.request(d).on("response", function X (res, result) {
                 if (res.statusCode === 200) {
-                    ui.results(result);
+                    formatResult(result);
                     moreResults();
                 } else if (!d._404 && res.statusCode === 404) {
                     // Perhaps the client hasn't connected yet?

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -71,7 +71,9 @@ formatters = {
 };
 
 // Default, nicely formatted output for the console.
-function default_formatter (result, verbose, log) {
+function consoleFormatter (result, verbose, log) {
+    log = log || exports.log;
+
     everything.failed += result.failed;
     everything.passed += result.passed;
 
@@ -80,6 +82,7 @@ function default_formatter (result, verbose, log) {
     var icon = result.failed ? exports.bad : exports.good;
     var em = result.failed ? color.red : color.green;
     var fa = result.failed ? color.red : function(str) { return str; };
+
     log(em(icon) + "  " + color.bold(result.name) + " on " + browser);
 
     var ua = "        (" + result.ua + ")";
@@ -101,18 +104,18 @@ function default_formatter (result, verbose, log) {
     log(str + ', ' + str2);
 
     if (result.failed) {
-        var lastSuite;
+        var lastTestCase;
         for (var k in result) {
-            var suite = result[k];
-            if ("object" === typeof suite) {
-                if (suite.failed) {
-                    for (var k1 in suite) {
-                        var test = suite[k1];
+            var testCase = result[k];
+            if ("object" === typeof testCase) {
+                if (testCase.failed) {
+                    for (var k1 in testCase) {
+                        var test = testCase[k1];
                         if ("object" === typeof test) {
                             if ("fail" === test.result) {
-                                if (!lastSuite || lastSuite !== suite.name) {
-                                    log("   in", color.bold(suite.name));
-                                    lastSuite = suite.name;
+                                if (!lastTestCase || lastTestCase !== testCase.name) {
+                                    log("   in", color.bold(testCase.name));
+                                    lastTestCase = testCase.name;
                                 }
                                 var msg = test.message.split('\n');
                                 log("    ", color.bold(color.red(test.name)) + ":", msg[0]);
@@ -131,17 +134,6 @@ function default_formatter (result, verbose, log) {
 
     if (!--pendingResults) summarize();
 };
-
-formatters.console = default_formatter;
-
-exports.formatters = formatters;
-
-// Display test results.
-function results (result, verbose) {
-    formatters.console(result, verbose);
-};
-
-exports.results = results;
 
 // Print a summary of test results then exit.
 function summarize () {
@@ -163,6 +155,66 @@ function summarize () {
 }
 
 exports.summarize = summarize;
+
+formatters.console = consoleFormatter;
+
+// Output formatted as a subunit stream.
+function subunitFormatter (result, verbose, log) {
+    log = log || exports.log;
+
+    var browser = Browser.forAgent(result.ua);
+
+    browser = browser.replace(/[^\w]/g, " ");
+    browser = browser.replace(/\s+/g, "_");
+
+    var suite, suiteName, testCase, caseName, test, testName, msg;
+
+    for (var k in result) {
+        suite = result[k];
+        if ("object" === typeof suite) {
+            suiteName = result.name + "." + suite.name;
+            for (var k1 in suite) {
+                test = suite[k1];
+                if ("object" === typeof test) {
+                    testName = suiteName + "." + test.name + "." + browser;
+                    log("test: " + testName);
+                    if ("fail" === test.result) {
+                        if (test.message) {
+                            log("failure: " + testName + " [");
+                            msg = test.message.split('\n');
+                            for (var m = 0; m < msg.length; m++) {
+                                log(msg[m]);
+                            }
+                            log("]");
+                        } else {
+                            log("failure: " + testName);
+                        }
+                    } else if ("pass" === test.result) {
+                        log("success: " + testName);
+                    }
+                }
+            }
+        }
+    }
+
+    if (!--pendingResults) {
+        if (everything.failed) {
+            process.exit(1);
+        } else {
+            process.exit(0);
+        }
+    }
+
+};
+
+formatters.subunit = subunitFormatter;
+
+exports.formatters = formatters;
+
+// Display test results.
+function results (result, verbose) {
+    formatters.console(result, verbose);
+};
 
 // Exit Yeti. If an `err` is provided, print infomration about it
 // and provide bug reporting information.

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -181,7 +181,7 @@ function subunitFormatter (result, verbose, log) {
     log = log || sys.puts;
 
     var browser = Browser.forAgent(result.ua),
-        timestamp = Date.parse(result.timestamp);
+        timestamp = Date.parse(result.timestamp) || Date.now();
 
     browser = browser.replace(/[^\w]/g, " ");
     browser = browser.replace(/\s+/g, "_");

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -67,8 +67,11 @@ var everything = {
     failed: 0
 };
 
-// Display test results.
-function results (result, verbose) {
+formatters = {
+};
+
+// Default, nicely formatted output for the console.
+function default_formatter (result, verbose, log) {
     everything.failed += result.failed;
     everything.passed += result.passed;
 
@@ -78,7 +81,7 @@ function results (result, verbose) {
     var em = result.failed ? color.red : color.green;
     var fa = result.failed ? color.red : function(str) { return str; };
     log(em(icon) + "  " + color.bold(result.name) + " on " + browser);
-    
+
     var ua = "        (" + result.ua + ")";
     if (browser === result.ua) {
         log(ua);
@@ -127,6 +130,15 @@ function results (result, verbose) {
     log("");
 
     if (!--pendingResults) summarize();
+};
+
+formatters.console = default_formatter;
+
+exports.formatters = formatters;
+
+// Display test results.
+function results (result, verbose) {
+    formatters.console(result, verbose);
 };
 
 exports.results = results;

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -158,16 +158,37 @@ exports.summarize = summarize;
 
 formatters.console = consoleFormatter;
 
+function zeroPad(num, count) {
+    var numZeropad = num + '';
+    while (numZeropad.length < count) {
+        numZeropad = "0" + numZeropad;
+    }
+    return numZeropad;
+};
+
+function iso8601(d) {
+    return d.getUTCFullYear() + '-'
+        + zeroPad(d.getUTCMonth() + 1, 2) + '-'
+        + zeroPad(d.getUTCDate(), 2) + 'T'
+        + zeroPad(d.getUTCHours(), 2) + ':'
+        + zeroPad(d.getUTCMinutes(), 2) + ':'
+        + zeroPad(d.getUTCSeconds(), 2) + '.'
+        + zeroPad(d.getUTCMilliseconds(), 3);
+};
+
 // Output formatted as a subunit stream.
 function subunitFormatter (result, verbose, log) {
     log = log || sys.puts;
 
-    var browser = Browser.forAgent(result.ua);
+    var browser = Browser.forAgent(result.ua),
+        timestamp = Date.parse(result.timestamp);
 
     browser = browser.replace(/[^\w]/g, " ");
     browser = browser.replace(/\s+/g, "_");
 
     var suite, suiteName, testCase, caseName, test, testName, msg;
+
+    log("time: " + iso8601(new Date(timestamp)));
 
     for (var k in result) {
         suite = result[k];
@@ -178,6 +199,10 @@ function subunitFormatter (result, verbose, log) {
                 if ("object" === typeof test) {
                     testName = suiteName + "." + test.name + "." + browser;
                     log("test: " + testName);
+                    if (test.duration) {
+                        timestamp = timestamp + test.duration;
+                        log("time: " + iso8601(new Date(timestamp)));
+                    }
                     if ("fail" === test.result) {
                         if (test.message) {
                             log("failure: " + testName + " [");

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -160,7 +160,7 @@ formatters.console = consoleFormatter;
 
 // Output formatted as a subunit stream.
 function subunitFormatter (result, verbose, log) {
-    log = log || exports.log;
+    log = log || sys.puts;
 
     var browser = Browser.forAgent(result.ua);
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     { "express" : "=1.0.0"
     , "connect" : "=0.5.0"
     , "jade" : "=0.5.7"
-    , "optimist" : "=0.1.1"
+    , "optimist" : "=0.1.6"
     }
 , "licenses" :
   [ { "type" : "BSD"

--- a/test/ui.js
+++ b/test/ui.js
@@ -1,0 +1,83 @@
+var vows = require("vows");
+var assert = require("assert");
+
+var ui = require("../lib/ui");
+
+vows.describe("UI").addBatch({
+    "Formatting results for console" : {
+        topic : function () {
+            var messages = [];
+            ui.formatters.console({
+                    "passed": 4,
+                    "failed": 1,
+                    "ignored": 0,
+                    "total": 5,
+                    "ua": "Mozilla/5.0 (X11; U; Linux x86_64; en-US) AppleWebKit/534.13 (KHTML, like Gecko) Chrome/9.0.597.19 Safari/534.13",
+                    "type": "report",
+                    "name": "YUI Test Results",
+                    "yuisuite":{
+                        "passed": 4,
+                        "failed": 1,
+                        "ignored": 0,
+                        "total": 5,
+                        "type": "testsuite",
+                        "name": "yuisuite",
+                        "Y.Anim":{
+                            "passed": 4,
+                            "failed": 1,
+                            "ignored": 0,
+                            "total": 5,
+                            "type":"testcase",
+                            "name":"Y.Anim",
+                            "test_getEl":{
+                                "result":"pass",
+                                "message":"Test passed.",
+                                "type":"test",
+                                "name":"test_getEl"
+                            },
+                            "test_isAnimated":{
+                                "result":"pass",
+                                "message":"Test passed.",
+                                "type":"test",
+                                "name":"test_isAnimat"
+                            },
+                            "test_stop":{
+                                "result":"fail",
+                                "message":"Test failed.",
+                                "type":"test",
+                                "name":"test_stop"
+                            },
+                            "test_onStart":{
+                                "result":"pass",
+                                "message":"Test passed.",
+                                "type":"test",
+                                "name":"test_onStart"
+                            },
+                            "test_endValue":{
+                                "result":"pass",
+                                "message":"Test passed.",
+                                "type":"test",
+                                "name":"test_endValue"
+                            }
+                        }
+                    }
+            }, false, function(msg) {messages.push(msg);});
+            return messages;
+        },
+        "should print results name as first line" : function (messages) {
+            assert.include(messages[0], "YUI Test Result");
+        },
+        "should print user agent on the first line" : function (messages) {
+            assert.include(messages[0], "on Chrome (9.0.597.19) / Linux");
+        },
+        "should contain an empty line as the last message" : function (messages) {
+            assert.equal(messages[messages.length - 1], "");
+        },
+        "should print number of passed tests" : function (messages) {
+            assert.include(messages[messages.length - 2], "4 passed");
+        },
+        "should print number of failed tests" : function (messages) {
+            assert.include(messages[messages.length - 2], "1 failed");
+        }
+    }
+}).export(module);

--- a/test/ui.js
+++ b/test/ui.js
@@ -12,60 +12,61 @@ vows.describe("UI").addBatch({
                     "failed": 1,
                     "ignored": 0,
                     "total": 5,
+                    "timestamp": "Wed Dec 22 2010 17:27:40 GMT-0200 (BRST)",
                     "ua": "Mozilla/5.0 (X11; U; Linux x86_64; en-US) AppleWebKit/534.13 (KHTML, like Gecko) Chrome/9.0.597.19 Safari/534.13",
                     "type": "report",
-                    "name": "YUI Test Results",
-                    "yuisuite":{
-                        "passed": 4,
+                    "name": "my.test.suite",
+                    "case1": {
+                        "passed": 2,
                         "failed": 1,
                         "ignored": 0,
-                        "total": 5,
-                        "type": "testsuite",
-                        "name": "yuisuite",
-                        "Y.Anim":{
-                            "passed": 4,
-                            "failed": 1,
-                            "ignored": 0,
-                            "total": 5,
-                            "type":"testcase",
-                            "name":"Y.Anim",
-                            "test_getEl":{
-                                "result":"pass",
-                                "message":"Test passed.",
-                                "type":"test",
-                                "name":"test_getEl"
-                            },
-                            "test_isAnimated":{
-                                "result":"pass",
-                                "message":"Test passed.",
-                                "type":"test",
-                                "name":"test_isAnimat"
-                            },
-                            "test_stop":{
-                                "result":"fail",
-                                "message":"Test failed.",
-                                "type":"test",
-                                "name":"test_stop"
-                            },
-                            "test_onStart":{
-                                "result":"pass",
-                                "message":"Test passed.",
-                                "type":"test",
-                                "name":"test_onStart"
-                            },
-                            "test_endValue":{
-                                "result":"pass",
-                                "message":"Test passed.",
-                                "type":"test",
-                                "name":"test_endValue"
-                            }
+                        "total": 3,
+                        "type": "testcase",
+                        "name": "case1",
+                        "test_getEl":{
+                            "result":"pass",
+                            "message":"Test passed.",
+                            "type":"test",
+                            "name":"test_getEl"
+                        },
+                        "test_isAnimated":{
+                            "result":"pass",
+                            "message":"Test passed.",
+                            "type":"test",
+                            "name":"test_isAnimat"
+                        },
+                        "test_stop":{
+                            "result":"fail",
+                            "message":"Yo, dawg. Test has failed.",
+                            "type":"test",
+                            "name":"test_stop"
+                        }
+                    },
+                    "case2": {
+                        "passed": 1,
+                        "failed": 1,
+                        "ignored": 0,
+                        "total": 2,
+                        "type": "testcase",
+                        "name": "case2",
+                        "test_onStart":{
+                            "result":"pass",
+                            "message":"Test passed.",
+                            "type":"test",
+                            "name":"test_onStart"
+                        },
+                        "test_endValue":{
+                            "result":"pass",
+                            "message":"Test passed.",
+                            "type":"test",
+                            "name":"test_endValue"
                         }
                     }
             }, false, function(msg) {messages.push(msg);});
             return messages;
         },
         "should print results name as first line" : function (messages) {
-            assert.include(messages[0], "YUI Test Result");
+            assert.include(messages[0], "my.test.suite");
         },
         "should print user agent on the first line" : function (messages) {
             assert.include(messages[0], "on Chrome (9.0.597.19) / Linux");
@@ -74,10 +75,86 @@ vows.describe("UI").addBatch({
             assert.equal(messages[messages.length - 1], "");
         },
         "should print number of passed tests" : function (messages) {
-            assert.include(messages[messages.length - 2], "4 passed");
+            assert.include(messages[1], "4 passed");
         },
         "should print number of failed tests" : function (messages) {
-            assert.include(messages[messages.length - 2], "1 failed");
+            assert.include(messages[1], "1 failed");
+        }
+    }
+}).addBatch({
+    "Formatting results for subunit" : {
+        topic : function () {
+            var messages = [];
+            ui.formatters.subunit({
+                    "passed": 4,
+                    "failed": 1,
+                    "ignored": 0,
+                    "total": 5,
+                    "timestamp": "Wed Dec 22 2010 17:27:40 GMT-0200 (BRST)",
+                    "ua": "Mozilla/5.0 (X11; U; Linux x86_64; en-US) AppleWebKit/534.13 (KHTML, like Gecko) Chrome/9.0.597.19 Safari/534.13",
+                    "type": "report",
+                    "name": "my.test.suite",
+                    "case1": {
+                        "passed": 2,
+                        "failed": 1,
+                        "ignored": 0,
+                        "total": 3,
+                        "type": "testcase",
+                        "name": "case1",
+                        "test_getEl":{
+                            "result":"pass",
+                            "message":"Test passed.",
+                            "type":"test",
+                            "name":"test_getEl"
+                        },
+                        "test_isAnimated":{
+                            "result":"pass",
+                            "message":"Test passed.",
+                            "type":"test",
+                            "name":"test_isAnimat"
+                        },
+                        "test_stop":{
+                            "result":"fail",
+                            "message":"Yo, dawg. Test has failed.",
+                            "type":"test",
+                            "name":"test_stop"
+                        }
+                    },
+                    "case2": {
+                        "passed": 1,
+                        "failed": 1,
+                        "ignored": 0,
+                        "total": 2,
+                        "type": "testcase",
+                        "name": "case2",
+                        "test_onStart":{
+                            "result":"pass",
+                            "message":"Test passed.",
+                            "type":"test",
+                            "name":"test_onStart"
+                        },
+                        "test_endValue":{
+                            "result":"pass",
+                            "message":"Test passed.",
+                            "type":"test",
+                            "name":"test_endValue"
+                        }
+                    }
+            }, false, function(msg) {messages.push(msg);});
+            return messages;
+        },
+        "should print full test name including suite and mangled user agent" : function (messages) {
+            assert.equal(messages[0], "test: my.test.suite.case1.test_getEl.Chrome_9_0_597_19_Linux");
+        },
+        "should print success plus test name for passing test" : function (messages) {
+            assert.equal(messages[1], "success: my.test.suite.case1.test_getEl.Chrome_9_0_597_19_Linux");
+        },
+        "should print failure plus test name for failed test" : function (messages) {
+            assert.equal(messages[5], "failure: my.test.suite.case1.test_stop.Chrome_9_0_597_19_Linux [");
+        },
+        "should print failure message after failure note" : function (messages) {
+            assert.equal(messages[6], "Yo, dawg. Test has failed.");
+            assert.equal(messages[7], "]");
         }
     }
 }).export(module);

--- a/test/ui.js
+++ b/test/ui.js
@@ -105,19 +105,22 @@ vows.describe("UI").addBatch({
                             "result":"pass",
                             "message":"Test passed.",
                             "type":"test",
-                            "name":"test_getEl"
+                            "name":"test_getEl",
+                            "duration": 25
                         },
                         "test_isAnimated":{
                             "result":"pass",
                             "message":"Test passed.",
                             "type":"test",
-                            "name":"test_isAnimat"
+                            "name":"test_isAnimat",
+                            "duration": 125
                         },
                         "test_stop":{
                             "result":"fail",
                             "message":"Yo, dawg. Test has failed.",
                             "type":"test",
-                            "name":"test_stop"
+                            "name":"test_stop",
+                            "duration": 12
                         }
                     },
                     "case2": {
@@ -131,30 +134,41 @@ vows.describe("UI").addBatch({
                             "result":"pass",
                             "message":"Test passed.",
                             "type":"test",
-                            "name":"test_onStart"
+                            "name":"test_onStart",
+                            "duration": 15
                         },
                         "test_endValue":{
                             "result":"pass",
                             "message":"Test passed.",
                             "type":"test",
-                            "name":"test_endValue"
-                        }
+                            "name":"test_endValue",
+                            "duration": 10
+                       }
                     }
             }, false, function(msg) {messages.push(msg);});
             return messages;
         },
+        "should test result timestamp in iso8601 format as the first line" : function (messages) {
+            assert.equal(messages[0], "time: 2010-12-22T19:27:40.000");
+        },
         "should print full test name including suite and mangled user agent" : function (messages) {
-            assert.equal(messages[0], "test: my.test.suite.case1.test_getEl.Chrome_9_0_597_19_Linux");
+            assert.equal(messages[1], "test: my.test.suite.case1.test_getEl.Chrome_9_0_597_19_Linux");
+        },
+        "should print a timestamp (initial + duration) for the first test" : function (messages) {
+            assert.equal(messages[2], "time: 2010-12-22T19:27:40.025");
         },
         "should print success plus test name for passing test" : function (messages) {
-            assert.equal(messages[1], "success: my.test.suite.case1.test_getEl.Chrome_9_0_597_19_Linux");
+            assert.equal(messages[3], "success: my.test.suite.case1.test_getEl.Chrome_9_0_597_19_Linux");
+        },
+        "should print a timestamp (initial + 1st duration + 2nd duration + test) for the failed test" : function (messages) {
+            assert.equal(messages[8], "time: 2010-12-22T19:27:40.162");
         },
         "should print failure plus test name for failed test" : function (messages) {
-            assert.equal(messages[5], "failure: my.test.suite.case1.test_stop.Chrome_9_0_597_19_Linux [");
+            assert.equal(messages[9], "failure: my.test.suite.case1.test_stop.Chrome_9_0_597_19_Linux [");
         },
         "should print failure message after failure note" : function (messages) {
-            assert.equal(messages[6], "Yo, dawg. Test has failed.");
-            assert.equal(messages[7], "]");
+            assert.equal(messages[10], "Yo, dawg. Test has failed.");
+            assert.equal(messages[11], "]");
         }
     }
 }).export(module);


### PR DESCRIPTION
In order to integrate yeti more closely with some of our projects, I'd like to add support for formatting the output of yeti as a subunit (http://pypi.python.org/pypi/python-subunit/0.0.6) stream. Once the output is in that format, there's a lot of tools that can be used to analyze and transform the output into other formats.
