### PR TITLE
Remove old brew warning

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -158,23 +158,6 @@ function exit (err) {
     if (err) {
         log(color.red("Fatal error") + ":", err);
 
-        // We require a specific version of Jade.
-        // If you have Homebrew installed, sometimes the global
-        // version of Jade is used instead of our version.
-        // What's worse, sometimes our dependencies directory
-        // isn't even put into `require.paths`! Then nothing works.
-        // This happens so often, I wrote this message for it.
-        if (process.execPath.indexOf("Cellar/node") !== -1) {
-            log();
-            log(color.red("Danger, Will Robinson.")
-                + " Your Node.js may have been installed by Homebrew.");
-            log("npm doesn't work correctly with Homebrew.");
-            log("Before reporting a Yeti bug, try reinstalling Node.js without brew.");
-            log("    Zero to Node guide: " + color.bold("http://gist.github.com/579814"));
-            log("    npm bug: " + color.bold("http://github.com/isaacs/npm/issues/issue/257"));
-            log();
-        }
-
         log("If you believe this is a bug in Yeti, please report it:");
         var meta = pkg.readPackageSync();
         log(color.bold("    " + meta.bugs.web));


### PR DESCRIPTION
I've been looking through the architecture of yeti so that I can hold a decent conversation with reid about how we implement a pluggable test output.  Then I remembered that reid had mentioned we didn't need the old brew warning anymore.  I figured I'd kill it while I was looking around...
