### PR TITLE
Fix showing version.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -304,7 +304,7 @@ exports.route = function (argv) {
         runBatch(options);
     } else if (options.server) {
         startServer(options);
-    } else if (options.argv.original[0] === "-v") {
+    } else if (options.version || options.argv.original[0] === "-v") {
         puts(meta.version);
     } else if (options.help) {
         puts(usage);


### PR DESCRIPTION
Please review this one. Currently, showing like following.

```
$ yeti -v
0.2.1pre
```

```
$ yeti --version
usage: /usr/local/bin/yeti [--version | -v] [--server | -s] [--port=<n>] [--hub=<url>] [--help]
 [--] [<HTML files>]
No files specified. To launch the Yeti server, specify --server.
```
