### PR TITLE
Fix for YUI Bug #64

### DIFF
--- a/lib/hub/test-server.js
+++ b/lib/hub/test-server.js
@@ -11,7 +11,7 @@ TestServer.prototype.tag = new RegExp(
     [
         "\\s*",
         "<",
-        "script",
+        "!DOCTYPE",
         ".*",
         "(/?)", // self-closing
         ">"
@@ -22,8 +22,8 @@ TestServer.prototype.tag = new RegExp(
 TestServer.prototype.inject = function (buffer) {
     var html = buffer.toString("utf8"),
         match = this.tag.exec(html),
-        // Append to the end if no match was found.
-        index = match ? match.index : html.length;
+        // Adding to the top of the page, if  DOCTYPE tag was not found.
+        index = match ? match.index + match[0].length : 0;
     return new Buffer(html.slice(0, index) +
             this.payload + html.slice(index), "utf8");
 };


### PR DESCRIPTION
Appending script tags right after DOCTYPE tag , if DOCTYPE is not on
the page , then scripts get added at the top, before any other html tag.
