### PR TITLE
Close #72 and #78: messenger.js tests and 404 fix

### DIFF
--- a/lib/hub/index.js
+++ b/lib/hub/index.js
@@ -347,7 +347,7 @@ Hub.prototype._createServer = function (router) {
                 }
             },
             function lastResort(req, res) {
-                if (req.method !== "GET" || req.method !== "HEAD") {
+                if (req.method !== "GET" && req.method !== "HEAD") {
                     res.message(405, "GET or HEAD method required.");
                 } else {
                     res.message(404, "Unable to find what you're looking for.");

--- a/lib/hub/middleware/messenger.js
+++ b/lib/hub/middleware/messenger.js
@@ -25,27 +25,10 @@ module.exports = function messengerProvider(renderConfig) {
          */
         res.message = function yetiMessage(code, message, subtitle) {
 
-
-            var hasBody = req.method.toUpperCase() !== "HEAD",
-                accept = req.headers.accept || "",
-                contentType;
-
-            if (accept.indexOf("html") !== -1) {
-                // TODO HTML error page
-                // contentType = "text/html";
-                contentType = "text/plain";
-            } else if (accept.indexOf("text/plain") !== -1) {
-                contentType = "text/plain";
-            } else {
-                if (accept.indexOf("css") !== -1) {
-                    contentType = "text/css";
-                } else {
-                    contentType = "application/javascript";
-                }
-            }
+            var hasBody = req.method.toUpperCase() !== "HEAD";
 
             res.writeHead(code, {
-                "Content-Type" : contentType
+                "Content-Type" : "text/plain"
             });
 
             if (!hasBody) {
@@ -55,32 +38,7 @@ module.exports = function messengerProvider(renderConfig) {
             subtitle = subtitle || STATUS_CODES[code];
             subtitle += "\n";
 
-            switch (contentType) {
-            /*
-            case "text/html":
-                var options = renderConfig;
-                options.subtitle = subtitle;
-                options.body = "<p>" + message + "</p>";
-                render(options, function (err, html) {
-                    if (err) {
-                        res.end(subtitle + message);
-                    } else {
-                        res.end(html);
-                    }
-                });
-                break;
-            */
-            case "text/css":
-            case "application/javascript":
-                message = "/" + "* " + subtitle + message + " *" + "/";
-                res.end(message);
-                break;
-            default:
-            // case "text/plain":
-                res.end(subtitle + message);
-                break;
-            }
-
+            res.end(subtitle + message);
         };
 
         next();

--- a/test/messenger.js
+++ b/test/messenger.js
@@ -8,8 +8,8 @@ var pact = require("pact");
 var Hub = require("../lib/hub");
 
 vows.describe("Yeti Hub HTTP errors").addBatch({
-    "Hub setup and connection" : {
-        topic : function () {
+    "Hub setup and connection": {
+        topic: function () {
             var vow = this,
                 hub = new Hub();
             hub.listen(function () {
@@ -21,79 +21,82 @@ vows.describe("Yeti Hub HTTP errors").addBatch({
         },
         "when a non-GET or HEAD request is used" : {
             topic : function (hub) {
-                var vow = this;
-                var req = http.request({
-                    host : hub.server.address().address,
-                    port : hub.server.address().port,
-                    method : "PUT"
-                });
+                var vow = this,
+                    address = hub.server.address(),
+                    req = http.request({
+                        host: address.address,
+                        port: address.port,
+                        method: "PUT"
+                    });
                 req.on("response", function (res) {
                     res.setEncoding("utf8");
                     res.on("data", function (chunk) {
                         vow.callback(null, {
-                            body : chunk,
-                            status : res.statusCode,
-                            headers : res.headers
+                            body: chunk,
+                            status: res.statusCode,
+                            headers: res.headers
                         });
                     });
                 });
                 req.end();
             },
-            "should return a 405 error" : function (topic) {
+            "should return a 405 error": function (topic) {
                 assert.equal(topic.status, 405);
             },
-            "should return the proper error message" : function (topic) {
+            "should return the proper error message": function (topic) {
                 assert.equal(topic.body, "Method Not Allowed\n" +
                                          "GET or HEAD method required.");
             }
         },
-        "when the desired route is not found" : {
-            topic : function (hub) {
-                var vow = this;
-                var req = http.request({
-                    host : hub.server.address().address,
-                    port : hub.server.address().port,
-                    path : "/foobar",
-                    method : "GET"
-                });
+        "when the desired route is not found": {
+            topic: function (hub) {
+                var vow = this,
+                    address = hub.server.address(),
+                    req = http.request({
+                        host: address.address,
+                        port: address.port,
+                        path: "/foobar",
+                        method: "GET"
+                    });
                 req.on("response", function (res) {
                     res.setEncoding("utf8");
                     res.on("data", function (chunk) {
                         vow.callback(null, {
-                            body : chunk,
-                            status : res.statusCode,
-                            headers : res.headers
+                            body: chunk,
+                            status: res.statusCode,
+                            headers: res.headers
                         });
                     });
                 });
                 req.end();
             },
-            "should return a 404 error" : function (topic) {
+            "should return a 404 error": function (topic) {
                 assert.equal(topic.status, 404);
             },
-            "should return the proper error message" : function (topic) {
+            "should return the proper error message": function (topic) {
                 assert.equal(topic.body, "Not Found\n" +
                                          "Unable to find what you're looking for.");
             }
         },
-        "when a HEAD request is not found" : {
-            topic : function (hub) {
-                var vow = this;
-                var req = http.request({
-                    host : hub.server.address().address,
-                    port : hub.server.address().port,
-                    path : "/foobar",
-                    method : "HEAD"
-                });
+        "when a HEAD request is not found": {
+            topic: function (hub) {
+                var vow = this,
+                    address = hub.server.address(),
+                    req = http.request({
+                        host: address.address,
+                        port: address.port,
+                        path: "/foobar",
+                        method: "HEAD"
+                    });
                 req.on("response", function (res) {
                     vow.callback(null, {
-                        status : res.statusCode,
-                        headers : res.headers
+                        status: res.statusCode,
+                        headers: res.headers
                     });
                 });
                 req.end();
             },
-            "should return a 404 error" : function (topic) {
+            "should return a 404 error": function (topic) {
                 assert.equal(topic.status, 404);
             }
         }

--- a/test/messenger.js
+++ b/test/messenger.js
@@ -11,7 +11,7 @@ vows.describe("Yeti Hub HTTP errors").addBatch({
         topic : pact.httpify(yeti.createHub()),
         "when a non-GET or HEAD request is used" : {
             topic : pact.request({
-                url : "/",
+                url : "http://localhost:9000",
                 method : "PUT"
             }),
             "should return a 405 error" : pact.code(405),
@@ -22,7 +22,7 @@ vows.describe("Yeti Hub HTTP errors").addBatch({
         },
         "when the desired route is not found" : {
             topic : pact.request({
-                url : "/foobar"
+                url : "http://localhost:9000/foobar"
             }),
             "should return a 404 error" : pact.code(404),
             "should return the proper error message" : function (topic) {
@@ -32,7 +32,7 @@ vows.describe("Yeti Hub HTTP errors").addBatch({
         },
         "when a HEAD request is not found" : {
             topic : pact.request({
-                url : "/foobar",
+                url : "http://localhost:9000/foobar",
                 method : "HEAD"
             }),
             "should end with no message" : function (topic) {

--- a/test/messenger.js
+++ b/test/messenger.js
@@ -16,8 +16,8 @@ vows.describe("Yeti Hub HTTP errors").addBatch({
             }),
             "should return a 405 error" : pact.code(405),
             "should return the proper error message" : function (topic) {
-                assert.equal(topic.body, "/* Method Not Allowed\n" +
-                                         "GET or HEAD method required. */");
+                assert.equal(topic.body, "Method Not Allowed\n" +
+                                         "GET or HEAD method required.");
             }
         },
         "when the desired route is not found" : {
@@ -26,8 +26,17 @@ vows.describe("Yeti Hub HTTP errors").addBatch({
             }),
             "should return a 404 error" : pact.code(404),
             "should return the proper error message" : function (topic) {
-                assert.equal(topic.body, "/* Not Found\n" + 
-                                         "Unable to find what you're looking for. */");
+                assert.equal(topic.body, "Not Found\n" + 
+                                         "Unable to find what you're looking for.");
+            }
+        },
+        "when a HEAD request is not found" : {
+            topic : pact.request({
+                url : "/foobar",
+                method : "HEAD"
+            }),
+            "should end with no message" : function (topic) {
+                assert.equal(topic.body, "");
             }
         }
     }

--- a/test/messenger.js
+++ b/test/messenger.js
@@ -1,0 +1,34 @@
+"use strict";
+
+var vows = require("vows");
+var assert = require("assert");
+var pact = require("pact");
+
+var yeti = require("../lib/yeti");
+
+vows.describe("Yeti Hub HTTP errors").addBatch({
+    "Hub setup and connection" : {
+        topic : pact.httpify(yeti.createHub()),
+        "when a non-GET or HEAD request is used" : {
+            topic : pact.request({
+                url : "/",
+                method : "PUT"
+            }),
+            "should return a 405 error" : pact.code(405),
+            "should return the proper error message" : function (topic) {
+                assert.equal(topic.body, "/* Method Not Allowed\n" +
+                                         "GET or HEAD method required. */");
+            }
+        },
+        "when the desired route is not found" : {
+            topic : pact.request({
+                url : "/foobar"
+            }),
+            "should return a 404 error" : pact.code(404),
+            "should return the proper error message" : function (topic) {
+                assert.equal(topic.body, "/* Not Found\n" + 
+                                         "Unable to find what you're looking for. */");
+            }
+        }
+    }
+}).export(module);

--- a/test/messenger.js
+++ b/test/messenger.js
@@ -1,42 +1,100 @@
 "use strict";
 
+var http = require("http");
 var vows = require("vows");
 var assert = require("assert");
 var pact = require("pact");
 
-var yeti = require("../lib/yeti");
+var Hub = require("../lib/hub");
 
 vows.describe("Yeti Hub HTTP errors").addBatch({
     "Hub setup and connection" : {
-        topic : pact.httpify(yeti.createHub()),
+        topic : function () {
+            var vow = this,
+                hub = new Hub();
+            hub.listen(function () {
+                vow.callback(null, hub);
+            });
+        },
+        teardown: function (hub) {
+            hub.close();
+        },
         "when a non-GET or HEAD request is used" : {
-            topic : pact.request({
-                url : "http://localhost:9000",
-                method : "PUT"
-            }),
-            "should return a 405 error" : pact.code(405),
+            topic : function (hub) {
+                var vow = this;
+                var req = http.request({
+                    host : hub.server.address().address,
+                    port : hub.server.address().port,
+                    method : "PUT"
+                });
+                req.on("response", function (res) {
+                    res.setEncoding("utf8");
+                    res.on("data", function (chunk) {
+                        vow.callback(null, {
+                            body : chunk,
+                            status : res.statusCode,
+                            headers : res.headers
+                        });
+                    });
+                });
+                req.end();
+            },
+            "should return a 405 error" : function (topic) {
+                assert.equal(topic.status, 405);
+            },
             "should return the proper error message" : function (topic) {
                 assert.equal(topic.body, "Method Not Allowed\n" +
                                          "GET or HEAD method required.");
             }
         },
         "when the desired route is not found" : {
-            topic : pact.request({
-                url : "http://localhost:9000/foobar"
-            }),
-            "should return a 404 error" : pact.code(404),
+            topic : function (hub) {
+                var vow = this;
+                var req = http.request({
+                    host : hub.server.address().address,
+                    port : hub.server.address().port,
+                    path : "/foobar",
+                    method : "GET"
+                });
+                req.on("response", function (res) {
+                    res.setEncoding("utf8");
+                    res.on("data", function (chunk) {
+                        vow.callback(null, {
+                            body : chunk,
+                            status : res.statusCode,
+                            headers : res.headers
+                        });
+                    });
+                });
+                req.end();
+            },
+            "should return a 404 error" : function (topic) {
+                assert.equal(topic.status, 404);
+            },
             "should return the proper error message" : function (topic) {
-                assert.equal(topic.body, "Not Found\n" + 
+                assert.equal(topic.body, "Not Found\n" +
                                          "Unable to find what you're looking for.");
             }
         },
         "when a HEAD request is not found" : {
-            topic : pact.request({
-                url : "http://localhost:9000/foobar",
-                method : "HEAD"
-            }),
-            "should end with no message" : function (topic) {
-                assert.equal(topic.body, "");
+            topic : function (hub) {
+                var vow = this;
+                var req = http.request({
+                    host : hub.server.address().address,
+                    port : hub.server.address().port,
+                    path : "/foobar",
+                    method : "HEAD"
+                });
+                req.on("response", function (res) {
+                    vow.callback(null, {
+                        status : res.statusCode,
+                        headers : res.headers
+                    });
+                });
+                req.end();
+            },
+            "should return a 404 error" : function (topic) {
+                assert.equal(topic.status, 404);
             }
         }
     }


### PR DESCRIPTION
Added tests for errors 404 and 405 with vows and pact.

Discovered issue #78 which is a simple logic error in providing the response error code.
