### PR TITLE
close #84: replace tty with readline

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var nopt = require("nopt");
-var tty = require("tty");
+var readline = require("readline");
 var meta = require("./package").readPackageSync();
 
 var Hub = require("./hub");
@@ -190,27 +190,14 @@ function runBatch(options) {
         // If we connected to a server, we would list
         // the current agents.
 
-        process.stdin.resume();
-        tty.setRawMode(true);
+        var rl = readline.createInterface(process.stdin, {});
 
-        process.stdin.on("keypress", function (s, key) {
-            if (key.ctrl) {
-                switch (key.name) {
-                case "c":
-                    process.kill(process.pid, "SIGINT");
-                    break;
-                case "z":
-                    process.kill(process.pid, "SIGSTP");
-                    break;
-                }
-            } else if (key.name !== "enter") {
-                error("Press Enter to begin testing, or Ctrl-C to exit.");
-            } else {
-                tty.setRawMode(false);
-                process.stdin.pause();
-                submitBatch(client, files);
-            }
+        rl.on('line', function (cmd) {
+            rl.removeAllListeners('line');
+            rl.close();
+            submitBatch(client, files);
         });
+
         error("Waiting for agents to connect at " + url + ".");
         error("When ready, press Enter to begin testing.");
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -192,8 +192,8 @@ function runBatch(options) {
 
         var rl = readline.createInterface(process.stdin, {});
 
-        rl.on('line', function (cmd) {
-            rl.removeAllListeners('line');
+        rl.on("line", function (cmd) {
+            rl.removeAllListeners("line");
             rl.close();
             submitBatch(client, files);
         });


### PR DESCRIPTION
Node v0.7.10 (pre) deprecates tty.setRawMode and the 'keypress' event.  Replaced with the readline module.
