### PR TITLE
Fixes bad 404 errors in Chrome

### DIFF
--- a/lib/hub/batch.js
+++ b/lib/hub/batch.js
@@ -185,7 +185,10 @@ Batch.prototype.handleFileRequest = function (server, filename) {
                     batch.report("agentError", agent, {
                         message: "Unable to serve the file: " + filename + ", ignoring"
                     });
-                    server.res.writeHead(404);
+                    server.res.writeHead(404, {
+                        "content-type": "text/plain"
+                    });
+                    server.res.end("Not Found");
                 }
 
                 server.res.end();


### PR DESCRIPTION
Chrome requires that a 404 error has a body to it before it throws an actual 404. This fix makes the YUI Loader and Get tests run successfully in Chrome
