### PR TITLE
Changed from /bin/sh to /bin/bash so it works on other platforms (linux)

### DIFF
--- a/go
+++ b/go
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 die () {
     filenames=($(ls -F scripts | grep '*' | sed -e 's/.sh\*//'))


### PR DESCRIPTION
`make lint` doesn't work on Linux because of unsupported syntax in the script.

Switching to `/bin/bash` instead of `/bin/sh` allows it to work on both Linux and OSX.
