### PR TITLE
Prevent FF from erring on 404ed script tags

### DIFF
--- a/lib/hub/view/public/inject.js
+++ b/lib/hub/view/public/inject.js
@@ -45,6 +45,10 @@
 
             // Handle user errors.
             win.onerror = function (message, url, line) {
+                //This prevents FF from throwing an Error on a 404d script include
+                if (message && message.toLowerCase().indexOf('error loading') > -1) {
+                    return true;
+                }
                 socket.json.emit("scriptError", {
                     message: message,
                     url: url,


### PR DESCRIPTION
In Firefox, if a script is 404ed `window.onerror` is triggered. This fix will throttle that and not throw the Yeti virtual error when a script tag is 404ed. (This makes all of the Get & Loader tests) to run to completion on Firefox.
