### PR TITLE
Agent disconnect

### DIFF
--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -112,7 +112,9 @@ Agent.prototype.available = function () {
 
 Agent.prototype.dispatch = function (urls) {
     if (!this.alive()) {
-        throw new Error("Agent is dead.");
+        //throw new Error("Agent is dead.");
+        //No need to throw here, just unload the agent and leave it for cleanup
+        return this.unload();
     }
 
     this.urlQueue = urls;
@@ -124,7 +126,7 @@ Agent.prototype.unload = function () {
     this.connected = false;
     this.seen = 0;
     this.waiting = false;
-    this.emit("disconnected");
+    this.emit("disconnect");
 };
 
 Agent.prototype.ping = function () {

--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -112,8 +112,6 @@ Agent.prototype.available = function () {
 
 Agent.prototype.dispatch = function (urls) {
     if (!this.alive()) {
-        //throw new Error("Agent is dead.");
-        //No need to throw here, just unload the agent and leave it for cleanup
         return this.unload();
     }
 

--- a/lib/hub/batch.js
+++ b/lib/hub/batch.js
@@ -105,6 +105,10 @@ Batch.prototype.setupAgentEmitter = function () {
     self.on("agentComplete", function (agent) {
         self.completeAgent(agent);
     });
+    // Complete the agent if it's disconnected
+    self.on("agentDisconnect", function (agent) {
+        self.completeAgent(agent);
+    });
 };
 
 Batch.prototype.getId = function () {

--- a/lib/hub/batch.js
+++ b/lib/hub/batch.js
@@ -95,6 +95,7 @@ Batch.prototype.setupAgentEmitter = function () {
     this.proxyEvent("complete", "agentComplete");
     this.proxyEvent("results", "agentResult");
     this.proxyEvent("beat", "agentBeat");
+    this.proxyEvent("disconnect", "agentDisconnect");
     this.proxyEvent("scriptError", "agentScriptError");
 
     // Attaching multiple .on listeners to the agentEmitter

--- a/lib/hub/view/public/capture.js
+++ b/lib/hub/view/public/capture.js
@@ -36,8 +36,24 @@
             }
 
             var agentId = getCookie("yeti-agent"),
+                win = window, moving = false, unload,
                 sock = new SockJS(getSockURL(resource, "tower")),
                 tower = new SimpleEvents(sock);
+
+
+            if ('function' === typeof win.onbeforeunload) {
+                unload = win.onbeforeunload;
+            }
+
+            win.onbeforeunload = function () {
+                if (!moving) {
+                    var img = new Image();
+                    img.src = '/ping/unload/' + agentId;
+                }
+                if (unload) {
+                    unload();
+                }
+            };
 
             tower.queueUntil("listening");
             tower.on("listening", function () {
@@ -55,6 +71,7 @@
                 document.getElementById("test").innerHTML = "Waiting for tests...";
             });
             tower.on("navigate", function (test) {
+                moving = true;
                 document.location.href = test;
             });
 


### PR DESCRIPTION
First proxying of `agentDisconnect` event. This will work on the capture page now.

You can start up the hub, then start a client, then connect two browsers. You should see the connect message in the cli. Now close one of the browsers and you should see the disconnect message in the cli. Now run the tests, they should complete because the agent was not registered at the time the batch ran.

This does not fix the agent going away after the test is submitted. I still need to figure out this case, the unload works in this case, but the agent is still registered to the batch and the batch doesn't know that it's gone.
