### PR TITLE
If no port is returned from url.parse, assume 80 not the default

### DIFF
--- a/lib/blizzard/index.js
+++ b/lib/blizzard/index.js
@@ -149,9 +149,7 @@ Blizzard.prototype.connect = function (url, cb) {
 
         host = url.hostname;
 
-        if (url.port) {
-            port = url.port;
-        }
+        port = url.port || 80; //We are requiring HTTP, so no port === 80
     }
 
     req = http.request({


### PR DESCRIPTION
If you do this:

`yeti --hub http://hub.davglass.com ./test.html` Yeti will try to connect to: `http://hub.davglass.com:9000/` instead.

The `url.parse` method returns no port when it parses `http://hub.davglass.com` (or `https://hub.davglass.com`). It only returns a port if one was specified in the url. To make this work a little nicer Yeti should check to see if `port` is returned and if not set it to `80` since that is the expected port from that url.
