### PR TITLE
Removing NFE from inject.js

### DIFF
--- a/lib/hub/view/public/inject.js
+++ b/lib/hub/view/public/inject.js
@@ -730,7 +730,7 @@ YUI.add("tempest-frameworks", function (Y, name) {
     ]
 });
 
-window.$yetify = function(options) {
+window.$yetify = function (options) {
     "use strict";
 
     // Do not start QUnit tests before bind,

--- a/lib/hub/view/public/inject.js
+++ b/lib/hub/view/public/inject.js
@@ -730,7 +730,7 @@ YUI.add("tempest-frameworks", function (Y, name) {
     ]
 });
 
-window.$yetify = function $yetify(options) {
+window.$yetify = function(options) {
     "use strict";
 
     // Do not start QUnit tests before bind,


### PR DESCRIPTION
NFEs cause problems in IE8 and below.
I experienced this issue when using bunyip with mocha.
