### PR TITLE
Remove NFE to work in IE8. Fix #87.

### DIFF
--- a/lib/hub/view/public/inject.js
+++ b/lib/hub/view/public/inject.js
@@ -730,7 +730,7 @@ YUI.add("tempest-frameworks", function (Y, name) {
     ]
 });
 
-window.$yetify = function $yetify(options) {
+window.$yetify = function (options) {
     "use strict";
 
     // Do not start QUnit tests before bind,


### PR DESCRIPTION
NFEs (named function expressions), while valuable for debugging, cause
problems in IE8. They're best avoided.

If you want to keep the function name in the stack-trace, you can use the
following pattern:

``` javascript
window.$yetify = (function () {
  function $yetify (options) {
    // ...
  }

  return $yetify;
})();
```

More info can be found [here](http://kangax.github.com/nfe/).
