### PR TITLE
Rename FooManager to AllFoo for Batches and Agents.

### DIFF
--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -16,11 +16,11 @@ var makeURLFromComponents = require("./url-builder");
  * @class Agent
  * @constructor
  * @inherits EventEmitter2
- * @param {AgentManager} manager AgentManager associated with this Agent.
+ * @param {AllAgents} allAgents Agent repository associated with this Agent.
  * @param {Object} registration Object with `id` and `ua` properties.
  */
-function Agent(manager, registration) {
-    this.manager = manager;
+function Agent(allAgents, registration) {
+    this.allAgents = allAgents;
 
     this.id = registration.id;
     this.ua = registration.ua;
@@ -239,7 +239,7 @@ Agent.prototype.removeTarget = function () {
  * @return {String} Next test URL, or capture page URL.
  */
 Agent.prototype.nextURL = function () {
-    var url = this.manager.hub.mountpoint;
+    var url = this.allAgents.hub.mountpoint;
 
     // this.target should be defined
     // if we're calling this function.

--- a/lib/hub/all-agents.js
+++ b/lib/hub/all-agents.js
@@ -11,18 +11,18 @@ var makeURLFromComponents = require("./url-builder");
 
 var REAP = true;
 if (process.env.YETI_NO_TIMEOUT) {
-    console.warn("Yeti AgentManager: Disabling agent reaping");
+    console.warn("Yeti AllAgents: Disabling agent reaping");
     REAP = false;
 }
 
 /**
- * @class AgentManager
+ * @class AllAgents
  * @constructor
  * @inherits EventEmitter2
- * @param {Hub} hub Yeti Hub associated with this AgentManager.
+ * @param {Hub} hub Hub associated with this object.
  * @param {Number} ttl TTL for associated Agents.
  */
-function AgentManager(hub, ttl) {
+function AllAgents(hub, ttl) {
     this.hub = hub;
     this.agents = {};
     this.boundTargets = {};
@@ -30,7 +30,7 @@ function AgentManager(hub, ttl) {
         verbose: true
     });
 
-    this.ttl = ttl || AgentManager.REAP_TTL;
+    this.ttl = ttl || AllAgents.REAP_TTL;
 
     this.defaults = {
         ttl: this.ttl
@@ -44,13 +44,13 @@ function AgentManager(hub, ttl) {
     this.bindEvents();
 }
 
-util.inherits(AgentManager, EventEmitter2);
+util.inherits(AllAgents, EventEmitter2);
 
-AgentManager.prototype.bindEvents = function () {
+AllAgents.prototype.bindEvents = function () {
     this.targetEmitter.on("dispatch", this.syncReapInterval.bind(this));
 };
 
-AgentManager.prototype.bindTarget = function (target) {
+AllAgents.prototype.bindTarget = function (target) {
     this.debug("bindTarget", target.id);
 
     target.pipeLog(this);
@@ -62,7 +62,7 @@ AgentManager.prototype.bindTarget = function (target) {
 
 };
 
-AgentManager.prototype.unbindTarget = function (target) {
+AllAgents.prototype.unbindTarget = function (target) {
     delete this.boundTargets[target.id];
 
     this.targetEmitter.remove(target);
@@ -70,7 +70,7 @@ AgentManager.prototype.unbindTarget = function (target) {
     this.syncReapInterval(target);
 };
 
-AgentManager.prototype.syncReapInterval = function () {
+AllAgents.prototype.syncReapInterval = function () {
     var ttl = this.ttl,
         baseline = this.defaults.ttl,
         boundTargets = this.boundTargets,
@@ -122,7 +122,7 @@ AgentManager.prototype.syncReapInterval = function () {
  */
 //TODO Make this configurable
 //TODO This should probably be allowed to be passed to an Agent as it's TTL too. Not sure
-AgentManager.REAP_TTL = (10 * 1000); //Default reap timeout
+AllAgents.REAP_TTL = (10 * 1000); //Default reap timeout
 
 /**
  * TODO
@@ -131,7 +131,7 @@ AgentManager.REAP_TTL = (10 * 1000); //Default reap timeout
  * @private
  */
 //TODO this needs to be destroyed at some point, just not sure where (`agentManager.destroy()` maybe)
-AgentManager.prototype._startReap = function () {
+AllAgents.prototype._startReap = function () {
     if (this._reap) {
         this.debug("About to reschedule reap to ttl =",
                 this.ttl + ", clearing old interval", this._reap);
@@ -146,7 +146,7 @@ AgentManager.prototype._startReap = function () {
  * @method reap
  * @private
  */
-AgentManager.prototype.reap = function () {
+AllAgents.prototype.reap = function () {
     this.getAgents().forEach(function (agent) {
         if (agent.expired()) {
             agent.abort();
@@ -160,7 +160,7 @@ AgentManager.prototype.reap = function () {
  * @method getAvailableAgents
  * @return {Agent[]} Agents marked available.
  */
-AgentManager.prototype.getAvailableAgents = function () {
+AllAgents.prototype.getAvailableAgents = function () {
     return this.getAgents().filter(function (agent) {
         return agent.available();
     });
@@ -176,7 +176,7 @@ AgentManager.prototype.getAvailableAgents = function () {
  * @method createTargetsForAgents
  * @return {Target[]} Targets.
  */
-AgentManager.prototype.createTargetsForAgents = function (agents) {
+AllAgents.prototype.createTargetsForAgents = function (agents) {
     var self = this,
         agentsByUA = {},
         targets = [];
@@ -210,7 +210,7 @@ AgentManager.prototype.createTargetsForAgents = function (agents) {
  * @method getAgents
  * @return {Agent[]} Agents.
  */
-AgentManager.prototype.getAgents = function () {
+AllAgents.prototype.getAgents = function () {
     var out = [],
         self = this;
     Object.keys(self.agents).forEach(function (id) {
@@ -226,11 +226,11 @@ AgentManager.prototype.getAgents = function () {
  * @param {Number} id Agent ID.
  * @return {Agent} The matching agent.
  */
-AgentManager.prototype.getAgent = function (id) {
+AllAgents.prototype.getAgent = function (id) {
     return this.agents[id];
 };
 
-AgentManager.prototype.removeAgent = function (id) {
+AllAgents.prototype.removeAgent = function (id) {
     var agent = this.agents[id];
 
     if (agent) {
@@ -250,7 +250,7 @@ AgentManager.prototype.removeAgent = function (id) {
  * @private
  * @param {Agent} agent Agent to add.
  */
-AgentManager.prototype.findTargetForNewAgent = function (agent) {
+AllAgents.prototype.findTargetForNewAgent = function (agent) {
     var self = this,
         ua = agent.ua,
         boundTargets = this.boundTargets,
@@ -275,7 +275,7 @@ AgentManager.prototype.findTargetForNewAgent = function (agent) {
  * @param {String} ua User-Agent.
  * @param {SimpleEvents} socket Socket.
  */
-AgentManager.prototype.connectAgent = function (id, ua, socket) {
+AllAgents.prototype.connectAgent = function (id, ua, socket) {
     var self = this,
         firstConnect = false,
         agent = self.agents[id],
@@ -322,4 +322,4 @@ AgentManager.prototype.connectAgent = function (id, ua, socket) {
     self.emit("agentSeen", agent.getName());
 };
 
-module.exports = AgentManager;
+module.exports = AllAgents;

--- a/lib/hub/all-batches.js
+++ b/lib/hub/all-batches.js
@@ -3,23 +3,23 @@
 var Batch = require("./batch");
 
 /**
- * A BatchManager keeps track of Batch objects on behalf of a Hub.
+ * AllBatches keeps track of Batch objects on behalf of a Hub.
  *
- * @class BatchManager
+ * @class AllBatches
  * @constructor
  * @param {Hub} hub Hub object for agentManager and mountpoint properties.
  */
-function BatchManager(hub) {
+function AllBatches(hub) {
     this.batches = {};
     this.hub = hub;
-    this.agentManager = hub.agentManager;
+    this.allAgents = hub.allAgents;
 }
 
-BatchManager.prototype.newId = function () {
+AllBatches.prototype.newId = function () {
     return String(Date.now()) + String(Math.random() * 0x100000 | 0);
 };
 
-BatchManager.prototype.destroyBatch = function (id) {
+AllBatches.prototype.destroyBatch = function (id) {
     this.batches[id].destroy();
     delete this.batches[id];
 };
@@ -31,10 +31,10 @@ BatchManager.prototype.destroyBatch = function (id) {
  * @param {Object} options Options (see `Client.createBatch()`).
  * @param {Function} reply Blizzard reply callback.
  */
-BatchManager.prototype.createBatch = function (session, options, reply) {
+AllBatches.prototype.createBatch = function (session, options, reply) {
     var batch;
 
-    options.batchManager = this;
+    options.allBatches = this;
     options.id = this.newId();
     options.session = session;
     batch = new Batch(options);
@@ -53,8 +53,8 @@ BatchManager.prototype.createBatch = function (session, options, reply) {
     }
 };
 
-BatchManager.prototype.getBatch = function (id) {
+AllBatches.prototype.getBatch = function (id) {
     return this.batches[id];
 };
 
-module.exports = BatchManager;
+module.exports = AllBatches;

--- a/lib/hub/batch.js
+++ b/lib/hub/batch.js
@@ -15,12 +15,12 @@ var WebDriverCollection = require("./webdriver-collection");
  * @class Batch
  * @constructor
  * @param {Object} options Options (for all options, see `Client.createBatch()`).
- * @param {BatchManager} options.batchManager
+ * @param {AllBatches} options.allBatches
  * @param {Number} options.id Batch ID.
  * @param {BlizzardSession} options.session Hub session.
  */
 function Batch(options) {
-    this.batchManager = options.batchManager;
+    this.allBatches = options.allBatches;
     this.id = options.id;
     this.session = options.session;
     this.tests = options.tests;
@@ -28,7 +28,7 @@ function Batch(options) {
     this.timeout = options.timeout;
     this.useProxy = options.useProxy;
 
-    var mountpoint = this.batchManager.hub.mountpoint;
+    var mountpoint = this.allBatches.hub.mountpoint;
 
     if (mountpoint === "/") {
         mountpoint = "";
@@ -197,7 +197,7 @@ Batch.prototype.launchAndDispatch = function (browsers, reply) {
         queue;
 
     self.managedBrowsers = new WebDriverCollection({
-        hub: self.batchManager.hub,
+        hub: self.allBatches.hub,
         browsers: browsers
     });
 
@@ -217,14 +217,14 @@ Batch.prototype.dispatch = function () {
     // TODO: Only select targets asked for.
 
     var targets,
-        agentManager = this.batchManager.agentManager,
+        allAgents = this.allBatches.allAgents,
         targetNames = [],
         query = this.query,
-        mountpoint = this.batchManager.hub.mountpoint,
+        mountpoint = this.allBatches.hub.mountpoint,
         self = this;
 
-    targets = agentManager.createTargetsForAgents(
-        agentManager.getAvailableAgents()
+    targets = allAgents.createTargetsForAgents(
+        allAgents.getAvailableAgents()
     );
 
     if (mountpoint === "/") {

--- a/lib/hub/index.js
+++ b/lib/hub/index.js
@@ -17,8 +17,8 @@ var EventEmitter2 = require("../event-emitter");
 
 var EventYoshi = require("eventyoshi");
 
-var BatchManager = require("./batch-manager");
-var AgentManager = require("./agent-manager");
+var AllAgents = require("./all-agents");
+var AllBatches = require("./all-batches");
 
 var HubListener = require("./listener");
 
@@ -87,10 +87,10 @@ var Hub = module.exports = function Hub(options) {
     // Setup IO events.
     this.tower.on("connection", this._onTowerConnection.bind(this));
 
-    this.agentManager = new AgentManager(this);
-    this.batchManager = new BatchManager(this);
+    this.allAgents = new AllAgents(this);
+    this.allBatches = new AllBatches(this);
 
-    this.agentManager.pipeLog(this);
+    this.allAgents.pipeLog(this);
 
     this._setupEvents();
 
@@ -140,12 +140,12 @@ Hub.prototype._setupEvents = function () {
     var self = this;
 
     self.on("batch", function (session, data, reply) {
-        self.batchManager.createBatch(session, data, reply);
+        self.allBatches.createBatch(session, data, reply);
     });
 
-    self.agentManager.on("agentConnect", self.sessions.emit.bind(self.sessions, "rpc.agentConnect"));
-    self.agentManager.on("agentSeen", self.sessions.emit.bind(self.sessions, "rpc.agentSeen"));
-    self.agentManager.on("agentDisconnect", self.sessions.emit.bind(self.sessions, "rpc.agentDisconnect"));
+    self.allAgents.on("agentConnect", self.sessions.emit.bind(self.sessions, "rpc.agentConnect"));
+    self.allAgents.on("agentSeen", self.sessions.emit.bind(self.sessions, "rpc.agentSeen"));
+    self.allAgents.on("agentDisconnect", self.sessions.emit.bind(self.sessions, "rpc.agentDisconnect"));
 
     self.sessions.on("request.batch", function (args, reply) {
         self.emit("batch", this.child, args[0], reply);
@@ -153,7 +153,7 @@ Hub.prototype._setupEvents = function () {
 
     self.sessions.on("request.agents", function (args, reply) {
         var agentNames = [];
-        self.agentManager.getAvailableAgents().forEach(function (agent) {
+        self.allAgents.getAvailableAgents().forEach(function (agent) {
             agentNames.push(agent.getName());
         });
         reply(null, [agentNames]);
@@ -226,7 +226,7 @@ Hub.prototype.generateId = function () {
  * @private
  */
 Hub.prototype._handleTestRequest = function (server, agentId, batchId, path) {
-    var batch = this.batchManager.getBatch(batchId),
+    var batch = this.allBatches.getBatch(batchId),
         file = urlParser.parse(path).pathname;
 
     if (!batch) {
@@ -269,7 +269,7 @@ Hub.prototype._onTowerConnection = function (socket) {
             client.emit("error", "ID required");
         }
 
-        self.agentManager.connectAgent(id, message.ua, client);
+        self.allAgents.connectAgent(id, message.ua, client);
 
         self.debug("SockJS register done");
         client.emit("ready", id);
@@ -393,7 +393,7 @@ Hub.prototype._createRouter = function () {
         var opts = file.split('/'),
             action = opts[0],
             id = opts[1],
-            agent = self.agentManager.getAgent(id);
+            agent = self.allAgents.getAgent(id);
 
         //Keeps it safe from outside execution
         if (agent && action === "unload") {

--- a/lib/hub/target.js
+++ b/lib/hub/target.js
@@ -14,11 +14,11 @@ var makeURLFromComponents = require("./url-builder");
  * @class Target
  * @constructor
  * @inherits EventEmitter2
- * @param {AgentManager} manager AgentManager associated with this Agent.
- * @param {Agent[]} Agents.
+ * @param {AllAgents} allAgents Agent repository associated with this Target.
+ * @param {Agent[]} agents Agents to include in this Target.
  */
-function Target(manager, agents) {
-    this.manager = manager;
+function Target(allAgents, agents) {
+    this.allAgents = allAgents;
     this.agents = {};
 
     this.id = String(Date.now()) + String(Math.random() * 0x100000 | 0);
@@ -133,7 +133,7 @@ Target.prototype.setupEvents = function () {
 };
 
 Target.prototype.makeURL = function (agentId, test) {
-    var url = this.manager.hub.mountpoint;
+    var url = this.allAgents.hub.mountpoint;
 
     if (test && this.useDirectURLs) {
         this.debug("makeURL using direct URL:", test);


### PR DESCRIPTION
The motivation here is to make it clear what the purpose of the Manager objects are. Manager used here is an unclear name. They are repositories of things held in-memory, so just call them what they are: holders of all the objects of a certain kind.
