### PR TITLE
Ensure all tests have results before firing complete

### DIFF
--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -353,8 +353,8 @@ Agent.prototype.expired = function () {
     var age = Date.now() - this.seen,
         ttl = this.ttl;
 
-    if (this.target) {
-        ttl = this.target.ttl;
+    if (this.target && this.target.testSpec) {
+        ttl = this.target.testSpec.getTimeoutMilliseconds();
     }
 
     this.debug("expired check, age:", age, "ttl:", ttl);

--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -212,7 +212,7 @@ Agent.prototype.setTarget = function (target) {
         this.targetEmitter.add(target);
         this.debug("Added to Target", target.id);
 
-        if (this.target.hasTests()) {
+        if (!this.target.tests.didComplete()) {
             // Tests are already available.
             this.next();
         }
@@ -326,6 +326,9 @@ Agent.prototype.abort = function () {
     this.emit("agentError", {
         message: "Agent timed out running test: " + this.currentUrl
     });
+    if (this.target) {
+        this.target.tests.getByUrl(this.currentUrl).setResults({});
+    }
     this.next(); //to next test
 };
 

--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -38,7 +38,6 @@ function Agent(allAgents, registration) {
     this.seen = new Date();
     this.connected = true;
 
-    this.dispatchedTests = 0;
     this.target = null;
     this.currentUrl = null;
 
@@ -229,7 +228,7 @@ Agent.prototype.removeTarget = function () {
 
 /**
  * Get the value for the next URL,
- * removing it from `this.urlQueue`.
+ * removing it from the Target's queue.
  *
  * Fires our complete event when no more
  * URLs are in the queue, then returns

--- a/lib/hub/all-batches.js
+++ b/lib/hub/all-batches.js
@@ -28,15 +28,18 @@ AllBatches.prototype.destroyBatch = function (id) {
  * Create a new Batch.
  *
  * @param {BlizzardSession} session Hub session.
- * @param {Object} options Options (see `Client.createBatch()`).
+ * @param {Object} spec Test specification. (see `Client.createBatch()`).
  * @param {Function} reply Blizzard reply callback.
  */
-AllBatches.prototype.createBatch = function (session, options, reply) {
-    var batch;
+AllBatches.prototype.createBatch = function (session, spec, reply) {
+    var batch,
+        options = {};
 
+    options.spec = spec;
     options.allBatches = this;
     options.id = this.newId();
     options.session = session;
+
     batch = new Batch(options);
 
     this.batches[options.id] = batch;

--- a/lib/hub/batch.js
+++ b/lib/hub/batch.js
@@ -26,15 +26,15 @@ function Batch(options) {
     this.id = options.id;
     this.session = options.session;
 
-    this.spec = new TestSpecification(options.spec);
-
     var mountpoint = this.allBatches.hub.mountpoint;
 
     if (mountpoint === "/") {
         mountpoint = "";
     }
 
-    this.spec.setMountpoint(mountpoint);
+    options.spec.mountpoint = mountpoint;
+    options.spec.batchId = options.id;
+    this.spec = new TestSpecification(options.spec);
 
     this.testServer = new TestServer(
         '<script src="' + mountpoint + '/agent/public/inject.js"></script>'
@@ -297,6 +297,9 @@ Batch.prototype.handleFileRequest = function (server, agentId, filename) {
                     batch.report("agentError", agent, {
                         message: "Unable to serve the test: " + filename
                     });
+                    if (agent.target) {
+                        agent.target.tests.getByUrl(filename).setResults({});
+                    }
                     server.res.writeHead(302, {
                         "Location": agent.nextURL()
                     });

--- a/lib/hub/batch.js
+++ b/lib/hub/batch.js
@@ -94,7 +94,7 @@ Batch.prototype.destroy = function () {
         var target = self.targets[id];
 
         self.targetEmitter.remove(target);
-        target.dispatch(self.id, []);
+        target.dispatch(self.id, TestSpecification.empty());
     });
 
     self.batchSession.unbind();
@@ -248,16 +248,8 @@ Batch.prototype.dispatch = function () {
         self.runningTargets[id] = true;
 
         self.targetEmitter.add(target);
-        
-        if (!self.spec.useProxy) {
-            target.useDirectURLsUntilComplete();
-        }
 
-        if ("number" === typeof self.spec.timeout) {
-            target.setTTLUntilComplete(self.spec.timeout * 1000);
-        }
-
-        target.dispatch(self.id, self.spec.createURLs());
+        target.dispatch(self.id, self.spec);
     });
 
 };

--- a/lib/hub/batch.js
+++ b/lib/hub/batch.js
@@ -5,6 +5,7 @@ var util = require("util");
 var EventEmitter2 = require("../event-emitter");
 var EventYoshi = require("eventyoshi");
 
+var TestSpecification = require("./test-specification");
 var TestServer = require("./test-server");
 
 var WebDriverCollection = require("./webdriver-collection");
@@ -14,25 +15,26 @@ var WebDriverCollection = require("./webdriver-collection");
  *
  * @class Batch
  * @constructor
- * @param {Object} options Options (for all options, see `Client.createBatch()`).
+ * @param {Object} options Options
  * @param {AllBatches} options.allBatches
  * @param {Number} options.id Batch ID.
  * @param {BlizzardSession} options.session Hub session.
+ * @param {Object} options.spec Test specification, see constructor for TestSpecification.
  */
 function Batch(options) {
     this.allBatches = options.allBatches;
     this.id = options.id;
     this.session = options.session;
-    this.tests = options.tests;
-    this.query = options.query;
-    this.timeout = options.timeout;
-    this.useProxy = options.useProxy;
+
+    this.spec = new TestSpecification(options.spec);
 
     var mountpoint = this.allBatches.hub.mountpoint;
 
     if (mountpoint === "/") {
         mountpoint = "";
     }
+
+    this.spec.setMountpoint(mountpoint);
 
     this.testServer = new TestServer(
         '<script src="' + mountpoint + '/agent/public/inject.js"></script>'
@@ -219,7 +221,6 @@ Batch.prototype.dispatch = function () {
     var targets,
         allAgents = this.allBatches.allAgents,
         targetNames = [],
-        query = this.query,
         mountpoint = this.allBatches.hub.mountpoint,
         self = this;
 
@@ -227,21 +228,16 @@ Batch.prototype.dispatch = function () {
         allAgents.getAvailableAgents()
     );
 
-    if (mountpoint === "/") {
-        mountpoint = "";
-    }
-
     targetNames = targets.map(function (target) {
         return target.getName();
     });
 
     self.batchSession.emit("rpc.dispatch", targetNames);
 
-    self.debug("dispatch, query:", query, "targets:", targets);
+    self.debug("dispatch targets:", targets);
 
     targets.forEach(function (target) {
-        var id = target.getId(),
-            urls = [];
+        var id = target.getId();
 
         if (self.destroyed) {
             // We were destroyed on the same tick.
@@ -253,21 +249,15 @@ Batch.prototype.dispatch = function () {
 
         self.targetEmitter.add(target);
         
-        if (self.useProxy) {
-            self.tests.forEach(function (test) {
-                urls.push(test + (query ? "?" + query : ""));
-            });
-        } else {
-            // Call slice to pass each urlQueue by value, not by reference.
-            urls = self.tests.slice();
+        if (!self.spec.useProxy) {
             target.useDirectURLsUntilComplete();
         }
 
-        if ("number" === typeof self.timeout) {
-            target.setTTLUntilComplete(self.timeout * 1000);
+        if ("number" === typeof self.spec.timeout) {
+            target.setTTLUntilComplete(self.spec.timeout * 1000);
         }
 
-        target.dispatch(self.id, urls);
+        target.dispatch(self.id, self.spec.createURLs());
     });
 
 };
@@ -299,7 +289,7 @@ Batch.prototype.handleFileRequest = function (server, agentId, filename) {
         agent = batch.getAgent(agentId);
     }
 
-    fileInBatch = batch.tests.some(function (test) {
+    fileInBatch = batch.spec.tests.some(function (test) {
         return test === filename;
     });
 

--- a/lib/hub/literal-test.js
+++ b/lib/hub/literal-test.js
@@ -1,15 +1,36 @@
 "use strict";
 
+/**
+ * @module literal-test
+ */
+
 var util = require("util");
 var Test = require("./test");
 
+/**
+ * LiteralTest represents a test that is a relative URL
+ * to a location served outside of Yeti.
+ *
+ * @class LiteralTest
+ * @constructor
+ * @extends Test
+ * @param {Object} options Options.
+ * @param {String} options.location Location of this test.
+ */
 function LiteralTest(options) {
     Test.call(this, options);
 }
 
 util.inherits(LiteralTest, Test);
 
-// @override
+/**
+ * Get the URL for this Test for the given Agent ID.
+ *
+ * @method getUrlForAgentId
+ * @override
+ * @param {String} agentId Agent ID.
+ * @return {String} Relative URL from this test's mountpoint.
+ */
 LiteralTest.prototype.getUrlForAgentId = function (agentId) {
     return this.location;
 };

--- a/lib/hub/literal-test.js
+++ b/lib/hub/literal-test.js
@@ -1,0 +1,17 @@
+"use strict";
+
+var util = require("util");
+var Test = require("./test");
+
+function LiteralTest(options) {
+    Test.call(this, options);
+}
+
+util.inherits(LiteralTest, Test);
+
+// @override
+LiteralTest.prototype.getUrlForAgentId = function (agentId) {
+    return this.location;
+};
+
+module.exports = LiteralTest;

--- a/lib/hub/null-test.js
+++ b/lib/hub/null-test.js
@@ -1,0 +1,18 @@
+"use strict";
+
+var util = require("util");
+
+var Test = require("./test");
+
+function NullTest(options) {
+    this.mountpoint = options.mountpoint;
+    this.results = null;
+}
+
+util.inherits(NullTest, Test);
+
+NullTest.prototype.getUrlForAgentId = function (agentId) {
+    return this.mountpoint + "agent/" + agentId;
+};
+
+module.exports = NullTest;

--- a/lib/hub/null-test.js
+++ b/lib/hub/null-test.js
@@ -1,9 +1,23 @@
 "use strict";
 
+/**
+ * @module null-test
+ */
+
 var util = require("util");
 
 var Test = require("./test");
 
+/**
+ * NullTest represents the absence of a Test.
+ * For Yeti, this means the browser should move
+ * back to the capture page.
+ *
+ * @class NullTest
+ * @constructor
+ * @param {Object} options Options.
+ * @param {String} options.mountpoint Normalized mountpoint.
+ */
 function NullTest(options) {
     this.mountpoint = options.mountpoint;
     this.results = null;
@@ -11,6 +25,14 @@ function NullTest(options) {
 
 util.inherits(NullTest, Test);
 
+/**
+ * Get a URL to the capture page for the given Agent ID.
+ *
+ * @method getUrlForAgentId
+ * @override
+ * @param {String} agentId
+ * @return {String} Relative URL for the capture page, relative to the mountpoint.
+ */
 NullTest.prototype.getUrlForAgentId = function (agentId) {
     return this.mountpoint + "agent/" + agentId;
 };

--- a/lib/hub/null-tests.js
+++ b/lib/hub/null-tests.js
@@ -1,0 +1,34 @@
+"use strict";
+
+var assert = require("assert");
+var util = require("util");
+
+var Tests = require("./tests");
+var NullTest = require("./null-test");
+
+function NullTests(options) {
+    this.setMountpoint(options.mountpoint);
+    this.nullTest = new NullTest(this);
+}
+
+util.inherits(NullTests, Tests);
+
+NullTests.createForMountpoint = function (mountpoint) {
+    return new NullTests({
+        mountpoint: mountpoint
+    });
+};
+
+NullTests.prototype.peek = function () {
+    return this.nullTest;
+};
+
+NullTests.prototype.next = function () {
+    return this.peek();
+};
+
+NullTests.prototype.didComplete = function () {
+    return true;
+};
+
+module.exports = NullTests;

--- a/lib/hub/null-tests.js
+++ b/lib/hub/null-tests.js
@@ -1,11 +1,26 @@
 "use strict";
 
-var assert = require("assert");
+/**
+ * @module null-tests
+ */
+
 var util = require("util");
 
 var Tests = require("./tests");
 var NullTest = require("./null-test");
 
+/**
+ * NullTests represents an void collection of tests.
+ * Requested actions should move the browser back to
+ * the capture page where it can recieve more tests,
+ * which is accomplished by returning a NullTest when
+ * asked for the next Test.
+ *
+ * @class NullTests
+ * @constructor
+ * @param {Object} options Options.
+ * @param {String} options.mountpoint Normalized mountpoint.
+ */
 function NullTests(options) {
     this.setMountpoint(options.mountpoint);
     this.nullTest = new NullTest(this);
@@ -13,20 +28,52 @@ function NullTests(options) {
 
 util.inherits(NullTests, Tests);
 
+/**
+ * Create an instance of NullTests for the given mountpoint.
+ *
+ * @method createForMountpoint
+ * @param {String} mountpoint
+ */
 NullTests.createForMountpoint = function (mountpoint) {
     return new NullTests({
         mountpoint: mountpoint
     });
 };
 
+/**
+ * Return the NullTest.
+ *
+ * @method peek
+ * @override
+ * @return {NullTest} Instance of NullTest for our mountpoint.
+ */
 NullTests.prototype.peek = function () {
     return this.nullTest;
 };
 
+/**
+ * Return the NullTest.
+ *
+ * TODO: Refactor to make this override not needed.
+ *
+ * @method next
+ * @override
+ * @return {NullTest} Instance of NullTest for our mountpoint.
+ */
 NullTests.prototype.next = function () {
     return this.peek();
 };
 
+/**
+ * Determine if tests are waiting to run.
+ * Always true for NullTests.
+ *
+ * TODO: Refactor to make this override not needed.
+ *
+ * @method didComplete
+ * @override
+ * @return {Boolean} True.
+ */
 NullTests.prototype.didComplete = function () {
     return true;
 };

--- a/lib/hub/target.js
+++ b/lib/hub/target.js
@@ -28,6 +28,7 @@ function Target(allAgents, agents) {
     EventEmitter2.call(this);
 
     this.batchId = null;
+    this.testSpec = null;
     this.urlQueue = [];
 
     this.useDirectURLs = false;
@@ -192,12 +193,23 @@ Target.prototype.hasTests = function () {
  *
  * @method dispatch
  * @param {String} batchId Batch ID.
- * @param {Array} urls URLs to test.
+ * @param {TestSpecification} testSpec Test specification.
  */
-Target.prototype.dispatch = function (batchId, urls) {
+Target.prototype.dispatch = function (batchId, testSpec) {
     this.batchId = batchId;
+    this.testSpec = testSpec;
+
+    var urls = testSpec.createURLs();
     this.dispatchedTests = urls.length;
     this.urlQueue = urls;
+
+    if (!testSpec.useProxy) {
+        this.useDirectURLsUntilComplete();
+    }
+
+    if ("number" === typeof testSpec.timeout) {
+        this.setTTLUntilComplete(testSpec.timeout * 1000);
+    }
 
     this.debug("Emit dispatch for batchId", batchId);
     this.emit("dispatch", batchId);

--- a/lib/hub/target.js
+++ b/lib/hub/target.js
@@ -7,6 +7,8 @@ var EventYoshi = require("eventyoshi");
 var parseUA = require("./ua");
 var makeURLFromComponents = require("./url-builder");
 
+var NullTests = require("./null-tests");
+
 /**
  * An Target is a collection of Agents
  * that share the load of testing a Batch.
@@ -29,6 +31,8 @@ function Target(allAgents, agents) {
 
     this.batchId = null;
     this.testSpec = null;
+    this.nullTests = new NullTests.createForMountpoint(allAgents.hub.mountpoint);
+    this.tests = this.nullTests;
     this.urlQueue = [];
 
     this.debug("Setup agentEmitter for", agents);
@@ -100,7 +104,10 @@ Target.prototype.getId = function () {
 Target.prototype.setupEvents = function () {
     var self = this;
 
-    self.agentEmitter.on("results", self.emit.bind(self, "results"));
+    self.agentEmitter.on("results", function (data) {
+        self.tests.getByUrl(data.url).setResults(data);
+        self.emit("results", data);
+    });
     self.agentEmitter.on("scriptError", self.emit.bind(self, "scriptError"));
     self.agentEmitter.on("beat", self.emit.bind(self, "beat"));
     self.agentEmitter.on("agentError", self.emit.bind(self, "agentError"));
@@ -109,20 +116,6 @@ Target.prototype.setupEvents = function () {
     self.agentEmitter.on("disconnect", function () {
         self.agentEmitter.remove(this.child);
     });
-};
-
-Target.prototype.makeURL = function (agentId, test) {
-    var url = this.allAgents.hub.mountpoint;
-
-    if (test && this.testSpec && !this.testSpec.useProxy) {
-        this.debug("makeURL using direct URL:", test);
-        return test;
-    }
-
-    url = makeURLFromComponents(url, agentId, this.batchId, test);
-
-    this.debug("makeURL:", url);
-    return url;
 };
 
 /**
@@ -138,21 +131,17 @@ Target.prototype.makeURL = function (agentId, test) {
  * @return {String} Next test URL, or capture page URL.
  */
 Target.prototype.nextURL = function (agentId) {
-    var url;
-
-    if (this.urlQueue.length) {
-        url = this.makeURL(agentId, this.urlQueue.shift());
-        this.emit("progress", {
-            total: this.dispatchedTests,
-            current: this.dispatchedTests - this.urlQueue.length
-        });
-    } else {
-        url = this.makeURL(agentId);
+    if (this.tests.didComplete()) {
         this.emit("complete");
         this.batchId = null;
     }
 
-    return url;
+    this.emit("progress", {
+        total: this.tests.totalSubmitted(),
+        current: this.tests.totalSubmitted() - this.tests.totalPending()
+    });
+
+    return this.tests.next().getUrlForAgentId(agentId);
 };
 
 /**
@@ -178,11 +167,16 @@ Target.prototype.dispatch = function (batchId, testSpec) {
     this.testSpec = testSpec;
 
     var urls = testSpec.createURLs();
+
+    // TODO: Remove these
     this.dispatchedTests = urls.length;
     this.urlQueue = urls;
+    // END TODO
+    this.tests = testSpec.createTests();
 
     this.debug("Emit dispatch for batchId", batchId);
     this.emit("dispatch", batchId);
+
 };
 
 module.exports = Target;

--- a/lib/hub/target.js
+++ b/lib/hub/target.js
@@ -31,7 +31,6 @@ function Target(allAgents, agents) {
     this.testSpec = null;
     this.urlQueue = [];
 
-    this.useDirectURLs = false;
     this.ttl = 45000;
 
     this.debug("Setup agentEmitter for", agents);
@@ -107,13 +106,6 @@ Target.prototype.setTTLUntilComplete = function (ttl) {
 };
 
 /**
- * @method useDirectURLsUntilComplete
- */
-Target.prototype.useDirectURLsUntilComplete = function () {
-    this.useDirectURLs = true;
-};
-
-/**
  * Setup events.
  *
  * @method setupEvents
@@ -136,7 +128,7 @@ Target.prototype.setupEvents = function () {
 Target.prototype.makeURL = function (agentId, test) {
     var url = this.allAgents.hub.mountpoint;
 
-    if (test && this.useDirectURLs) {
+    if (test && this.testSpec && !this.testSpec.useProxy) {
         this.debug("makeURL using direct URL:", test);
         return test;
     }
@@ -202,10 +194,6 @@ Target.prototype.dispatch = function (batchId, testSpec) {
     var urls = testSpec.createURLs();
     this.dispatchedTests = urls.length;
     this.urlQueue = urls;
-
-    if (!testSpec.useProxy) {
-        this.useDirectURLsUntilComplete();
-    }
 
     if ("number" === typeof testSpec.timeout) {
         this.setTTLUntilComplete(testSpec.timeout * 1000);

--- a/lib/hub/target.js
+++ b/lib/hub/target.js
@@ -31,8 +31,6 @@ function Target(allAgents, agents) {
     this.testSpec = null;
     this.urlQueue = [];
 
-    this.ttl = 45000;
-
     this.debug("Setup agentEmitter for", agents);
     this.agentEmitter = new EventYoshi();
     this.agentEmitter.proxy("setTarget");
@@ -91,18 +89,6 @@ Target.prototype.getAgent = function (agentId) {
  */
 Target.prototype.getId = function () {
     return this.id;
-};
-
-/**
- * Set a new TTL.
- * The old TTL will be restored when the complete event fires.
- *
- * @method setTTLUntilComplete
- * @param {Number} ttl TTL in milliseconds.
- */
-Target.prototype.setTTLUntilComplete = function (ttl) {
-    this.debug("setTTLUntilComplete:", ttl);
-    this.ttl = ttl;
 };
 
 /**
@@ -194,10 +180,6 @@ Target.prototype.dispatch = function (batchId, testSpec) {
     var urls = testSpec.createURLs();
     this.dispatchedTests = urls.length;
     this.urlQueue = urls;
-
-    if ("number" === typeof testSpec.timeout) {
-        this.setTTLUntilComplete(testSpec.timeout * 1000);
-    }
 
     this.debug("Emit dispatch for batchId", batchId);
     this.emit("dispatch", batchId);

--- a/lib/hub/target.js
+++ b/lib/hub/target.js
@@ -33,7 +33,6 @@ function Target(allAgents, agents) {
     this.testSpec = null;
     this.nullTests = new NullTests.createForMountpoint(allAgents.hub.mountpoint);
     this.tests = this.nullTests;
-    this.urlQueue = [];
 
     this.debug("Setup agentEmitter for", agents);
     this.agentEmitter = new EventYoshi();
@@ -145,16 +144,6 @@ Target.prototype.nextURL = function (agentId) {
 };
 
 /**
- * Determine if this Target has tests ready to run.
- *
- * @method hasTests
- * @return {Boolean} True if tests are available, false otherwise.
- */
-Target.prototype.hasTests = function () {
-    return !!this.urlQueue.length;
-};
-
-/**
  * Set the URL queue to the given URL array
  * and advance the browser to the first test.
  *
@@ -165,15 +154,7 @@ Target.prototype.hasTests = function () {
 Target.prototype.dispatch = function (batchId, testSpec) {
     this.batchId = batchId;
     this.testSpec = testSpec;
-
-    var urls = testSpec.createURLs();
-
-    // TODO: Remove these
-    this.dispatchedTests = urls.length;
-    this.urlQueue = urls;
-    // END TODO
     this.tests = testSpec.createTests();
-
     this.debug("Emit dispatch for batchId", batchId);
     this.emit("dispatch", batchId);
 

--- a/lib/hub/test-specification.js
+++ b/lib/hub/test-specification.js
@@ -66,37 +66,6 @@ TestSpecification.prototype.getTimeoutMilliseconds = function () {
     return this.timeout * 1000;
 };
 
-/**
- * Creates an array of tests for a Target.
- *
- * TODO: This should create Test objects for the Target
- * that can retain test results.
- *
- * @method createURLs
- * @return {String[]} Array of URLs.
- */
-TestSpecification.prototype.createURLs = function () {
-    var urls = [],
-        query = this.query;
-
-    if (query) {
-        query = "?" + query;
-    } else {
-        query = "";
-    }
-
-    if (this.useProxy) {
-        this.tests.forEach(function (test) {
-            urls.push(test + query);
-        });
-    } else {
-        // Get a copy of the tests, not a reference.
-        urls = this.tests.slice();
-    }
-
-    return urls;
-};
-
 TestSpecification.prototype.createTests = function () {
     return new Tests(this);
 };

--- a/lib/hub/test-specification.js
+++ b/lib/hub/test-specification.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var Tests = require("./tests");
+
 /**
  * TestSpecification details information about tests in a Test
  * that need to be relayed to a given Target.
@@ -7,6 +9,7 @@
  * @class TestSpecification
  * @constructor
  * @param {Object} spec From `Client.createBatch()`.
+ * @param {Number} spec.batchId Batch ID.
  * @param {String[]} spec.tests Tests. Either relative paths to `spec.basedir` or URL pathnames.
  * @param {String} [spec.basedir] Root path for serving tests. Required if `useProxy` is true or not provided.
  * @param {String} [spec.query] Query string additions for test URLs.
@@ -17,13 +20,14 @@
  *                           If not provided, defaults to true.
  */
 function TestSpecification(spec) {
+    this.batchId = spec.batchId;
     this.tests = spec.tests;
     this.query = spec.query;
     this.basedir = spec.basedir;
     this.timeout = spec.timeout || TestSpecification.DEFAULT_TIMEOUT;
     this.useProxy = spec.useProxy;
 
-    this.mountpount = "";
+    this.mountpount = this.setMountpoint(spec.mountpoint);
 }
 
 TestSpecification.DEFAULT_TIMEOUT = 45;
@@ -43,6 +47,11 @@ TestSpecification.empty = function () {
 };
 
 TestSpecification.prototype.setMountpoint = function (mountpoint) {
+    if (!mountpoint) {
+        mountpoint = "/";
+    } else if (mountpoint === "" || mountpoint[mountpoint.length - 1] !== "/") {
+        mountpoint += "/";
+    }
     this.mountpoint = mountpoint;
 };
 
@@ -86,6 +95,10 @@ TestSpecification.prototype.createURLs = function () {
     }
 
     return urls;
+};
+
+TestSpecification.prototype.createTests = function () {
+    return new Tests(this);
 };
 
 module.exports = TestSpecification;

--- a/lib/hub/test-specification.js
+++ b/lib/hub/test-specification.js
@@ -1,0 +1,64 @@
+"use strict";
+
+/**
+ * TestSpecification details information about tests in a Test
+ * that need to be relayed to a given Target.
+ *
+ * @class TestSpecification
+ * @constructor
+ * @param {Object} spec From `Client.createBatch()`.
+ * @param {String[]} spec.tests Tests. Either relative paths to `spec.basedir` or URL pathnames.
+ * @param {String} [spec.basedir] Root path for serving tests. Required if `useProxy` is true or not provided.
+ * @param {String} [spec.query] Query string additions for test URLs.
+ * @param {Number} [spec.timeout] Per-test timeout in seconds. Default is 45 seconds.
+ *                                  If no activity occurs before the timeout, the next test is loaded.
+ * @param {Boolean} [spec.useProxy] True if tests are filenames to proxy to the Hub.
+ *                           false if they are literal URL pathnames.
+ *                           If not provided, defaults to true.
+ */
+function TestSpecification(spec) {
+    this.tests = spec.tests;
+    this.query = spec.query;
+    this.basedir = spec.basedir;
+    this.timeout = spec.timeout;
+    this.useProxy = spec.useProxy;
+
+    this.mountpount = "";
+}
+
+TestSpecification.prototype.setMountpoint = function (mountpoint) {
+    this.mountpoint = mountpoint;
+};
+
+/**
+ * Creates an array of tests for a Target.
+ *
+ * TODO: This should create Test objects for the Target
+ * that can retain test results.
+ *
+ * @method createURLs
+ * @return {String[]} Array of URLs.
+ */
+TestSpecification.prototype.createURLs = function () {
+    var urls = [],
+        query = this.query;
+
+    if (query) {
+        query = "?" + query;
+    } else {
+        query = "";
+    }
+
+    if (this.useProxy) {
+        this.tests.forEach(function (test) {
+            urls.push(test + query);
+        });
+    } else {
+        // Get a copy of the tests, not a reference.
+        urls = this.tests.slice();
+    }
+
+    return urls;
+};
+
+module.exports = TestSpecification;

--- a/lib/hub/test-specification.js
+++ b/lib/hub/test-specification.js
@@ -46,6 +46,13 @@ TestSpecification.empty = function () {
     });
 };
 
+/**
+ * Set and normalize the mountpoint for use in creating URLs
+ * for Test objects.
+ *
+ * @method setMountpoint
+ * @param {String} mountpoint
+ */
 TestSpecification.prototype.setMountpoint = function (mountpoint) {
     if (!mountpoint) {
         mountpoint = "/";
@@ -54,7 +61,6 @@ TestSpecification.prototype.setMountpoint = function (mountpoint) {
     }
     this.mountpoint = mountpoint;
 };
-
 
 /**
  * Get the timeout in milliseconds.
@@ -66,6 +72,12 @@ TestSpecification.prototype.getTimeoutMilliseconds = function () {
     return this.timeout * 1000;
 };
 
+/**
+ * Create a Tests object from this specification.
+ *
+ * @method createTests
+ * @return {Tests} Created Tests.
+ */
 TestSpecification.prototype.createTests = function () {
     return new Tests(this);
 };

--- a/lib/hub/test-specification.js
+++ b/lib/hub/test-specification.js
@@ -20,11 +20,13 @@ function TestSpecification(spec) {
     this.tests = spec.tests;
     this.query = spec.query;
     this.basedir = spec.basedir;
-    this.timeout = spec.timeout;
+    this.timeout = spec.timeout || TestSpecification.DEFAULT_TIMEOUT;
     this.useProxy = spec.useProxy;
 
     this.mountpount = "";
 }
+
+TestSpecification.DEFAULT_TIMEOUT = 45;
 
 /**
  * Creates a new TestSpecification with no tests.
@@ -42,6 +44,17 @@ TestSpecification.empty = function () {
 
 TestSpecification.prototype.setMountpoint = function (mountpoint) {
     this.mountpoint = mountpoint;
+};
+
+
+/**
+ * Get the timeout in milliseconds.
+ *
+ * @method getTimeoutMilliseconds
+ * @return {Number} Timeout in milliseconds.
+ */
+TestSpecification.prototype.getTimeoutMilliseconds = function () {
+    return this.timeout * 1000;
 };
 
 /**

--- a/lib/hub/test-specification.js
+++ b/lib/hub/test-specification.js
@@ -26,6 +26,20 @@ function TestSpecification(spec) {
     this.mountpount = "";
 }
 
+/**
+ * Creates a new TestSpecification with no tests.
+ * This is used by `Batch.destroy()` to return browsers to the capture page.
+ *
+ * @method empty
+ * @static
+ * @return {TestSpecification} Empty TestSpecification.
+ */
+TestSpecification.empty = function () {
+    return new TestSpecification({
+        tests: []
+    });
+};
+
 TestSpecification.prototype.setMountpoint = function (mountpoint) {
     this.mountpoint = mountpoint;
 };

--- a/lib/hub/test.js
+++ b/lib/hub/test.js
@@ -1,0 +1,24 @@
+"use strict";
+
+function Test(options) {
+    this.query = options.query;
+    this.location = options.location;
+    this.batchId = options.batchId;
+    this.mountpoint = options.mountpoint;
+    this.results = null;
+}
+
+Test.prototype.getUrlForAgentId = function (agentId) {
+    var url = this.mountpoint;
+    url += "agent/" + agentId;
+    url += "/batch/" + this.batchId;
+    url += "/test/" + this.location;
+    if (this.query) { url += "?" + this.query; }
+    return url;
+};
+
+Test.prototype.setResults = function (results) {
+    this.results = results;
+};
+
+module.exports = Test;

--- a/lib/hub/test.js
+++ b/lib/hub/test.js
@@ -1,5 +1,21 @@
 "use strict";
 
+/**
+ * @module test
+ */
+
+/**
+ * Test represents a test file on disk.
+ * May be overridden by subclasses to represent other types.
+ *
+ * @class Test
+ * @constructor
+ * @param {Object} options Options.
+ * @param {String} options.location Location of this test.
+ * @param {String} [options.query] Query string for this test.
+ * @param {String} [options.batchId] Batch ID for this test.
+ * @param {String} [options.mountpoint] Mountpoint for this test.
+ */
 function Test(options) {
     this.query = options.query;
     this.location = options.location;
@@ -8,6 +24,13 @@ function Test(options) {
     this.results = null;
 }
 
+/**
+ * Get the URL for this Test for the given Agent ID.
+ *
+ * @method getUrlForAgentId
+ * @param {String} agentId Agent ID.
+ * @return {String} Relative URL from this test's mountpoint.
+ */
 Test.prototype.getUrlForAgentId = function (agentId) {
     var url = this.mountpoint;
     url += "agent/" + agentId;
@@ -17,6 +40,13 @@ Test.prototype.getUrlForAgentId = function (agentId) {
     return url;
 };
 
+/**
+ * Set the results property.
+ * If not falsy, test will be considered to have results.
+ *
+ * @method setResults
+ * @param {Object} results Results formatted as a YUI Test result.
+ */
 Test.prototype.setResults = function (results) {
     this.results = results;
 };

--- a/lib/hub/tests.js
+++ b/lib/hub/tests.js
@@ -1,9 +1,20 @@
 "use strict";
 
+/**
+ * @module tests
+ */
+
 var Test = require("./test");
 var LiteralTest = require("./literal-test");
 var NullTest = require("./null-test");
 
+/**
+ * Tests represent a collection of Test objects.
+ *
+ * @class Tests
+ * @constructor
+ * @param {TestSpecification} spec Specification for constructing child Test objects.
+ */
 function Tests(spec) {
     this.children = {};
     this.initializeFromSpecification(spec);
@@ -12,10 +23,24 @@ function Tests(spec) {
     this.nullTest = new NullTest(spec);
 }
 
+/**
+ * Set the mountpoint.
+ *
+ * @method setMountpoint
+ * @param {String} mountpoint Mountpoint.
+ */
 Tests.prototype.setMountpoint = function (mountpoint) {
     this.mountpoint = mountpoint;
 };
 
+/**
+ * Get a Test object from this collection by a substring
+ * match on the given URL part.
+ *
+ * @method getByUrl
+ * @param {String} url URL part.
+ * @return {Test} Test for the given URL, or NullTest if not found.
+ */
 Tests.prototype.getByUrl = function (url) {
     var locations = Object.keys(this.children),
         length = locations.length,
@@ -33,6 +58,12 @@ Tests.prototype.getByUrl = function (url) {
     return this.nullTest;
 };
 
+/**
+ * Get an array of Test objects without results.
+ *
+ * @method getTestsWithoutResults
+ * @return {Test[]} Test objects without results.
+ */
 Tests.prototype.getTestsWithoutResults = function () {
     var self = this,
         testsWithoutResults = [];
@@ -46,6 +77,13 @@ Tests.prototype.getTestsWithoutResults = function () {
     return testsWithoutResults;
 };
 
+/**
+ * Initialize this object from the given TestSpecification.
+ *
+ * @method initializeFromSpecification
+ * @private
+ * @param {TestSpecification} spec
+ */
 Tests.prototype.initializeFromSpecification = function (spec) {
     var self = this,
         tests;
@@ -69,28 +107,65 @@ Tests.prototype.initializeFromSpecification = function (spec) {
     });
 };
 
+/**
+ * Determine if all child Tests have results.
+ *
+ * @method didComplete
+ * @return {Boolean} True if all tests have results, false otherwise.
+ */
 Tests.prototype.didComplete = function () {
     return this.getTestsWithoutResults().length === 0;
 };
 
+/**
+ * Get the total amount of Tests in this collection.
+ *
+ * @method totalSubmitted
+ * @return {Number} Number of Tests.
+ */
 Tests.prototype.totalSubmitted = function () {
     return Object.keys(this.children).length;
 };
 
+/**
+ * Get the amount of tests waiting to be sent to a browser.
+ *
+ * @method totalPending
+ * @return {Number} Number of Tests.
+ */
 Tests.prototype.totalPending = function () {
     return this.waitingToStart.length;
 };
 
+/**
+ * Get a test waiting to start at the given index.
+ *
+ * @method queuedTestAtIndex
+ * @param {Number} index
+ * @return {Test} Test at the given queue index, or NullTest if not defined.
+ */
 Tests.prototype.queuedTestAtIndex = function (index) {
     var test = this.children[this.waitingToStart[index]];
     if (!test) { test = this.nullTest; }
     return test;
 };
 
+/**
+ * Get the next Test in the queue.
+ *
+ * @method peek
+ * @return {Test} Next Test in queue, or NullTest if no Test objects are left.
+ */
 Tests.prototype.peek = function () {
     return this.queuedTestAtIndex(0);
 };
 
+/**
+ * Get the next Test in the queue and remove it from the queue.
+ *
+ * @method next
+ * @return {Test} Next Test in queue, or NullTest if no Test objects are left.
+ */
 Tests.prototype.next = function () {
     var nextTest = this.peek();
     this.waitingToStart.shift();

--- a/lib/hub/tests.js
+++ b/lib/hub/tests.js
@@ -1,0 +1,100 @@
+"use strict";
+
+var Test = require("./test");
+var LiteralTest = require("./literal-test");
+var NullTest = require("./null-test");
+
+function Tests(spec) {
+    this.children = {};
+    this.initializeFromSpecification(spec);
+    this.waitingToStart = Object.keys(this.children);
+
+    this.nullTest = new NullTest(spec);
+}
+
+Tests.prototype.setMountpoint = function (mountpoint) {
+    this.mountpoint = mountpoint;
+};
+
+Tests.prototype.getByUrl = function (url) {
+    var locations = Object.keys(this.children),
+        length = locations.length,
+        index = 0,
+        location;
+
+    for (; index < length; index += 1) {
+        location = locations[index];
+
+        if (url.indexOf(location) !== -1) {
+            return this.children[location];
+        }
+    }
+
+    return this.nullTest;
+};
+
+Tests.prototype.getTestsWithoutResults = function () {
+    var self = this,
+        testsWithoutResults = [];
+
+    Object.keys(self.children).forEach(function (location) {
+        var test = self.children[location];
+
+        if (!test.results) { testsWithoutResults.push(test); }
+    });
+
+    return testsWithoutResults;
+};
+
+Tests.prototype.initializeFromSpecification = function (spec) {
+    var self = this,
+        tests;
+
+    self.setMountpoint(spec.mountpoint);
+
+    spec.tests.forEach(function (location) {
+        var options = {},
+            TestCtor = LiteralTest;
+
+        options.location = location;
+        options.batchId = spec.batchId;
+
+        if (spec.useProxy) {
+            TestCtor = Test;
+            options.query = spec.query;
+            options.mountpoint = self.mountpoint;
+        }
+
+        self.children[location] = new TestCtor(options);
+    });
+};
+
+Tests.prototype.didComplete = function () {
+    return this.getTestsWithoutResults().length === 0;
+};
+
+Tests.prototype.totalSubmitted = function () {
+    return Object.keys(this.children).length;
+};
+
+Tests.prototype.totalPending = function () {
+    return this.waitingToStart.length;
+};
+
+Tests.prototype.queuedTestAtIndex = function (index) {
+    var test = this.children[this.waitingToStart[index]];
+    if (!test) { test = this.nullTest; }
+    return test;
+};
+
+Tests.prototype.peek = function () {
+    return this.queuedTestAtIndex(0);
+};
+
+Tests.prototype.next = function () {
+    var nextTest = this.peek();
+    this.waitingToStart.shift();
+    return nextTest;
+};
+
+module.exports = Tests;


### PR DESCRIPTION
This is also a refactor of test handling. No more simple urlQueue.

URLs are now generated by NullTest, Test, or LiteralTest.

We now collect test results, or an empty result if the test is 404 or times out. We do not fire complete until we got results for everything.

Previously, we'd fire complete when no more tests are in the queue. This was a problem for multiple browsers, since we would have the complete event fire when the queue is empty, but there could be other browsers running the final tests at the same time.

The mess that is mountpoint handling has largely been consolidated into TestSpecification#setMountpoint.

Test objects are created to belog in a Tests collection built by a TestSpecification. This may be too many layers, but it will keep the Batch module from growing bigger when it needs to be cleaned up already.
