### PR TITLE
Quit process after browsers quit, introduce end event

### DIFF
--- a/doc/api/index.mustache
+++ b/doc/api/index.mustache
@@ -160,6 +160,17 @@ This script should be included before all other scripts on the page, including Y
 This object is created internally by `client.createBatch()`.
 </p>
 
+<h4>Event: 'end'</h4>
+
+```
+function () {}
+```
+
+<p>
+Emitted after the complete event. If browsers were started, they were shut down.
+No more events will be fired.
+</p>
+
 <h4>Event: 'complete'</h4>
 
 ```
@@ -167,7 +178,8 @@ function () {}
 ```
 
 <p>
-Emitted when the batch is complete. No more events will be fired.
+Emitted when the batch is complete. No more results are expected.
+Browsers may be shutting down at this point. The end event will fire when all cleanup is complete.
 </p>
 
 <h4>Event: 'agentComplete'</h4>

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -263,6 +263,7 @@ CLI.prototype.submitBatch = function submitBatch(client, output, options, cb) {
     batch.on("agentBeat", reporter.handleAgentBeat.bind(reporter));
     batch.on("dispatch", reporter.handleDispatch.bind(reporter));
     batch.on("complete", reporter.handleComplete.bind(reporter));
+    batch.on("end", reporter.handleEnd.bind(reporter));
 };
 
 

--- a/lib/cli/reporter/feedback-line.js
+++ b/lib/cli/reporter/feedback-line.js
@@ -328,11 +328,16 @@ FeedbackLineReporter.prototype.handleComplete = function () {
     if (this.batchDetails.failed) {
         this.puts(color.red(BAD + " Failures") + ":", this.batchDetails.failed,
             "of", total, "tests failed.", durationString);
-        this.cli.exit(1);
     } else {
         this.puts(color.green(GOOD + " " + total + " tests passed!"), durationString);
-        this.cli.exit(0);
     }
+};
+
+/**
+ * @method handleEnd
+ */
+FeedbackLineReporter.prototype.handleEnd = function () {
+    this.cli.exit(this.batchDetails.failed ? 1 : 0);
 };
 
 module.exports = FeedbackLineReporter;

--- a/lib/cli/reporter/junit.js
+++ b/lib/cli/reporter/junit.js
@@ -173,6 +173,9 @@ JUnitReporter.prototype.handleAgentError = function (agent, details) {
 
 JUnitReporter.prototype.handleComplete = function () {
     this.puts('</testsuites>');
+};
+
+JUnitReporter.prototype.handleEnd = function () {
     this.cli.exit(0);
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -66,8 +66,14 @@ util.inherits(ClientBatch, EventEmitter2);
  */
 
 /**
- * The batch is complete. No more events will be fired.
+ * The batch is complete. Browsers may be shutting down.
  * @event complete
+ */
+
+/**
+ * The batch has finished, browsers have shut down.
+ * No more events will be fired.
+ * @event end
  */
 
 /**
@@ -127,6 +133,7 @@ ClientBatch.prototype.onAck = function (err, id) {
 
     self.batchSession = self.session.createNamespace("batch" + self.id);
 
+    self.batchSession.incomingBridge(self, "end");
     self.batchSession.incomingBridge(self, "complete");
     self.batchSession.incomingBridge(self, "dispatch");
     self.batchSession.incomingBridge(self, "agentComplete");
@@ -137,7 +144,7 @@ ClientBatch.prototype.onAck = function (err, id) {
     self.batchSession.incomingBridge(self, "agentPedanticError");
     self.batchSession.incomingBridge(self, "agentScriptError");
 
-    self.once("complete", function () {
+    self.once("end", function () {
         self.batchSession.unbind();
     });
 

--- a/lib/hub/all-batches.js
+++ b/lib/hub/all-batches.js
@@ -48,8 +48,8 @@ AllBatches.prototype.createBatch = function (session, spec, reply) {
 
     batch.batchSession.once("end", this.destroyBatch.bind(this, options.id));
 
-    if (options.launchBrowsers) {
-        batch.launchAndDispatch(options.launchBrowsers, reply);
+    if (options.spec.launchBrowsers) {
+        batch.launchAndDispatch(options.spec.launchBrowsers, reply);
     } else {
         reply(null, options.id);
         batch.dispatch();

--- a/lib/hub/batch.js
+++ b/lib/hub/batch.js
@@ -86,6 +86,12 @@ Batch.prototype.destroy = function () {
         return;
     }
 
+    function completer() {
+        self.emit("end");
+        self.batchSession.emit("rpc.end");
+        self.batchSession.unbind();
+    }
+
     self.destroyed = true;
 
     // Return all browsers to the capture page.
@@ -97,17 +103,15 @@ Batch.prototype.destroy = function () {
         target.dispatch(self.id, TestSpecification.empty());
     });
 
-    self.batchSession.unbind();
-
     if (self.managedBrowsers) {
-        self.managedBrowsers.quit();
+        self.managedBrowsers.quit(completer);
         delete self.managedBrowsers;
+    } else {
+        completer();
     }
 
     self.runningTargets = null;
     self.targets = null;
-
-    self.emit("end");
 };
 
 Batch.prototype.completeTarget = function (target) {

--- a/lib/hub/webdriver-collection.js
+++ b/lib/hub/webdriver-collection.js
@@ -10,7 +10,7 @@ function WebDriverCollection(options) {
     this.hub = options.hub;
 
     this.remote = options.hub.webdriver;
-    this.agentManager = options.hub.agentManager;
+    this.allAgents = options.hub.allAgents;
     this.browsers = [];
     this.agentIds = [];
     var address = options.hub.server.address();
@@ -33,7 +33,7 @@ WebDriverCollection.prototype.quit = function (cb) {
     });
 
     self.agentIds.forEach(function (agentId) {
-        self.agentManager.removeAgent(agentId);
+        self.allAgents.removeAgent(agentId);
     });
 
     self.browsers = [];
@@ -96,12 +96,12 @@ WebDriverCollection.prototype._launch = function (desired, cb) {
         function onAgent(agent) {
             if (agent.id === id) {
                 agentLoaded = true;
-                self.agentManager.removeListener("newAgent", onAgent);
+                self.allAgents.removeListener("newAgent", onAgent);
                 check();
             }
         }
 
-        self.agentManager.on("newAgent", onAgent);
+        self.allAgents.on("newAgent", onAgent);
         browser.get(url, onGet);
     }
 

--- a/test/unit/webdriver-collection.js
+++ b/test/unit/webdriver-collection.js
@@ -53,19 +53,19 @@ function createWdMock(topic, cb) {
     };
 }
 
-function MockAgentManager() {
+function MockAllAgents() {
     this.agents = {};
     EventEmitter2.call(this);
 }
 
-util.inherits(MockAgentManager, EventEmitter2);
+util.inherits(MockAllAgents, EventEmitter2);
 
-MockAgentManager.prototype.addAgent = function (agent) {
+MockAllAgents.prototype.addAgent = function (agent) {
     this.agents[agent.id] = agent;
     this.emit("newAgent", agent);
 };
 
-MockAgentManager.prototype.removeAgent = function (agent) {
+MockAllAgents.prototype.removeAgent = function (agent) {
     delete this.agents[agent.id];
 };
 
@@ -80,7 +80,7 @@ function createHubMock(topic) {
             }
         },
         webdriver: topic.wdOptions,
-        agentManager: new MockAgentManager()
+        allAgents: new MockAllAgents()
     };
 }
 
@@ -156,7 +156,7 @@ vows.describe("WebDriver Collection").addBatch({
 
                 topic.wdYoshi.on("navigate", function (url) {
                     topic.events.navigate.push(url);
-                    topic.hubMock.agentManager.addAgent({
+                    topic.hubMock.allAgents.addAgent({
                         id: /[\d]+$/.exec(url)[0]
                     });
                 });


### PR DESCRIPTION
If Yeti starts its Hub in the same process as the Client, the process can exit when the `complete` event fires. This will be before launched browsers have been told to shutdown.

Introduce the `end` event, which is fired after all cleanup on the Batch has occurred. Only quit the process after the `end` event is fired. If no browsers were launched, `end` fires after some final cleanup occurs after the `complete` event. Otherwise, `end` fires when browsers have been told to shutdown.

Also fixes leftover bustage in WebDriverCollection from the rename of agentManager to allAgents.
