### PR TITLE
Fix test timeout feature; rapid disconnects for crashed browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,15 @@ See the [echoecho README][ee-readme] for more details.
 
 #### Timeouts
 
-Yeti will disconnect a browser if it does not record any activity from it for 45 seconds.
+Yeti will move on to the next test if a test takes longer than 5 minutes (300 seconds).
 You can adjust this interval with the `--timeout` option.
 
 This will run Yeti with a 120 second timeout:
 
     $ yeti --timeout 120 test.html
+
+There isn't a general timeout setting. Yeti actively pings browsers about every
+2-5 seconds and disconnects them if they fail to respond to a ping three times.
 
 #### Query string parameters
 

--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -38,7 +38,7 @@ function Agent(allAgents, registration) {
     this.name = parseUA(this.ua);
 
     this.seen = new Date();
-    this.lastNavigate = new Date(0);
+    this.lastNavigate = new Date();
     this.connected = true;
 
     this.target = null;
@@ -66,6 +66,7 @@ function Agent(allAgents, registration) {
 
     this.lastHealthCheck = new Date(0);
     this.startPeriodicHealthCheck();
+    this.unresponsiveCycles = 0;
 }
 
 util.inherits(Agent, EventEmitter2);
@@ -80,7 +81,7 @@ util.inherits(Agent, EventEmitter2);
  * @type Number
  * @default 45000
  */
-Agent.TTL = 45000;
+Agent.TTL = 200000;
 
 /**
  * The Agent emitted a heartbeat.
@@ -148,6 +149,7 @@ Agent.prototype.setupEvents = function () {
     self.socketEmitter.proxy("end");
 
     self.socketEmitter.on("pong", function () {
+        console.log("got pong");
         self.ping();
     });
 
@@ -186,15 +188,46 @@ Agent.prototype.getName = function () {
     return this.name + " from " + this.remoteAddress;
 };
 
-Agent.prototype.healthCheck = function agentHealthCheck() {
-    if (!this.seenSince(new Date(this.lastHealthCheck.getTime() - 2000))) {
-        this.sendPing();
-    } else if (this.expired()) {
+// Browser starts.
+// 1. Browser disconnects.
+//    Normally fires unload and we never get here.
+//    NOP
+//
+// 2. Browser crashes.
+//    Stops responding to ping a few times.
+//    UNLOAD
+//
+// 3. Browser takes too long to run a test.
+//    Go to the next test.
+//    ABORT
+//
+// 4. Browser has not done anything in a while.
+//    PING
+Agent.prototype.healthCheck = function agentHealthCheck() { 
+    if (this.currentTestShouldTimeout()) {
+        console.log("giveUpOnCurrentTest");
+        this.giveUpOnCurrentTest();
+    } else if (this.shouldUnload()) {
+        console.log("unload");
         this.unload();
-    } else if ((Date.now() - this.lastNavigate.getTime()) > this.getTimeoutMilliseconds()) {
-        this.abort();
+    } else if (!this.seenSince(new Date(this.lastHealthCheck.getTime() - 2000))) {
+        console.log("sendPing");
+        this.sendPing();
     }
     this.lastHealthCheck = new Date();
+};
+
+/**
+ * @method currentTestShouldTimeout
+ * @private
+ * @return {Boolean}
+ */
+Agent.prototype.currentTestShouldTimeout = function () {
+    return (
+        this.target &&
+        this.unresponsiveCycles === 0 &&
+        (Date.now() - this.lastNavigate.getTime()) > this.getTimeoutMilliseconds()
+    );
 };
 
 Agent.prototype.startPeriodicHealthCheck = function () {
@@ -246,7 +279,9 @@ Agent.prototype.setTarget = function (target) {
         this.targetEmitter.add(target);
         this.debug("Added to Target", target.id);
 
-        if (!this.target.tests.didComplete()) {
+        console.log("NEW BROWSER ADDED TO TARGET!", this.target.tests.totalPending());
+        if (this.target.tests.totalPending() > 0) {
+            console.log("hasPending!");
             // Tests are already available.
             this.next();
         }
@@ -273,15 +308,21 @@ Agent.prototype.removeTarget = function () {
  * @return {String} Next test URL, or capture page URL.
  */
 Agent.prototype.nextURL = function () {
-    var url = this.allAgents.hub.mountpoint;
+    var url = this.allAgents.hub.mountpoint,
+        test;
 
     // this.target should be defined
     // if we're calling this function.
 
     if (this.target) {
-        url = this.target.nextURL(this.id);
+        test = this.target.nextTest();
+        this.currentTest = test;
+        this.currentTest.setExecuting(true);
         this.lastNavigate = new Date();
+        url = test.getUrlForAgentId(this.id);
+        console.log("nextTest", test, url);
     } else {
+        this.currentTest = null;
         // This agent is no longer a part of an Target.
         // This happens when a Batch is ended, esp.
         // when it's aborted.
@@ -324,6 +365,7 @@ Agent.prototype.queueSocketEmit = function (event, data) {
  * @return {Boolean} True if the browser is waiting, false otherwise
  */
 Agent.prototype.next = function () {
+    console.log("got Agent#next", (new Error()).stack);
     this.queueSocketEmit("navigate", this.nextURL());
     return !this.waiting;
 };
@@ -345,6 +387,9 @@ Agent.prototype.available = function () {
  */
 Agent.prototype.unload = function () {
     this.debug("disconnecting agent! stack:", (new Error()).stack);
+    if (this.currentTest) {
+        this.currentTest.isExecuting(false);
+    }
     this.stopPeriodicHealthCheck();
     this.connected = false;
     this.seen = new Date(0);
@@ -356,18 +401,17 @@ Agent.prototype.unload = function () {
  * Abort running the current test
  * and advance to the next test.
  *
- * @method abort
- * @deprecated
+ * @method giveUpOnCurrentTest
  */
-Agent.prototype.abort = function () {
+Agent.prototype.giveUpOnCurrentTest = function () {
     // XXX: This is not called anywhere.
     this.emit("abort");
     this.emit("agentError", {
         message: "Agent timed out running test: " + this.currentUrl
     });
-    if (this.target) {
-        // TODO Mark to re-run on another Agent in this Target instead
-        this.target.tests.getByUrl(this.currentUrl).setResults({});
+    if (this.currentTest) {
+        this.currentTest.setResults({});
+        this.currentTest.isExecuting(false);
     }
     this.next();
 };
@@ -379,11 +423,11 @@ Agent.prototype.abort = function () {
  * @method ping
  */
 Agent.prototype.ping = function () {
+    this.unresponsiveCycles = 0;
     this.connected = true;
     this.seen = new Date();
     this.emit("beat");
 };
-
 
 /**
  * Ask the browser to respond: is it still connected?
@@ -391,6 +435,7 @@ Agent.prototype.ping = function () {
  * @method sendPing
  */
 Agent.prototype.sendPing = function () {
+    this.unresponsiveCycles += 1;
     this.queueSocketEmit("ping");
 };
 
@@ -423,18 +468,15 @@ Agent.prototype.getTimeoutMilliseconds = function () {
 };
 
 /**
- * Check if this Agent is expired,
- * meaning that it has not connected
- * in the last minute.
+ * Check if this Agent should be unloaded,
+ * meaning that it has not pinged us for too long.
  *
- * @method expired
- * @return {Boolean} True if the Agent is expired, false otherwise.
+ * @method shouldUnload
+ * @return {Boolean} True if the Agent is should unload, false otherwise.
  */
-Agent.prototype.expired = function () {
-    var age = Date.now() - this.seen.getTime(),
-        ttl = 60000;
-    this.debug("expired check, age:", age, "ttl:", ttl);
-    return age > ttl;
+Agent.prototype.shouldUnload = function () {
+    console.log("shouldUnload: unresponsiveCycles:", this.unresponsiveCycles);
+    return this.unresponsiveCycles !== 0 && this.unresponsiveCycles > 3;
 };
 
 module.exports = Agent;

--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -203,7 +203,7 @@ Agent.prototype.getName = function () {
 //
 // 4. Browser has not done anything in a while.
 //    PING
-Agent.prototype.healthCheck = function agentHealthCheck() { 
+Agent.prototype.healthCheck = function agentHealthCheck() {
     if (this.currentTestShouldTimeout()) {
         console.log("giveUpOnCurrentTest");
         this.giveUpOnCurrentTest();
@@ -448,7 +448,7 @@ Agent.prototype.sendPing = function () {
  */
 Agent.prototype.seenSince = function (since) {
     return this.seen.getTime() > since.getTime();
-}
+};
 
 /**
  * Get the current timeout in milliseconds.

--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -66,7 +66,7 @@ function Agent(allAgents, registration) {
 
     this.lastHealthCheck = new Date(0);
     this.startPeriodicHealthCheck();
-    this.unresponsiveCycles = 0;
+    this.unresponsivePings = 0;
 }
 
 util.inherits(Agent, EventEmitter2);
@@ -227,7 +227,7 @@ Agent.prototype.currentTestShouldTimeout = function () {
         this.target &&
         this.currentTest &&
         !this.currentTest.isNull() &&
-        this.unresponsiveCycles === 0 &&
+        this.unresponsivePings === 0 &&
         (Date.now() - this.lastNavigate.getTime()) > this.getTimeoutMilliseconds()
     );
 };
@@ -425,7 +425,7 @@ Agent.prototype.giveUpOnCurrentTest = function () {
  * @method ping
  */
 Agent.prototype.ping = function () {
-    this.unresponsiveCycles = 0;
+    this.unresponsivePings = 0;
     this.connected = true;
     this.seen = new Date();
     this.emit("beat");
@@ -437,7 +437,7 @@ Agent.prototype.ping = function () {
  * @method sendPing
  */
 Agent.prototype.sendPing = function () {
-    this.unresponsiveCycles += 1;
+    this.unresponsivePings += 1;
     this.queueSocketEmit("ping");
 };
 
@@ -477,8 +477,8 @@ Agent.prototype.getTimeoutMilliseconds = function () {
  * @return {Boolean} True if the Agent is should unload, false otherwise.
  */
 Agent.prototype.shouldUnload = function () {
-    console.log("shouldUnload: unresponsiveCycles:", this.unresponsiveCycles);
-    return this.unresponsiveCycles !== 0 && this.unresponsiveCycles > 3;
+    console.log("shouldUnload: unresponsivePings:", this.unresponsivePings);
+    return this.unresponsivePings !== 0 && this.unresponsivePings > 3;
 };
 
 module.exports = Agent;

--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -149,7 +149,6 @@ Agent.prototype.setupEvents = function () {
     self.socketEmitter.proxy("end");
 
     self.socketEmitter.on("pong", function () {
-        console.log("got pong");
         self.ping();
     });
 
@@ -205,13 +204,10 @@ Agent.prototype.getName = function () {
 //    PING
 Agent.prototype.healthCheck = function agentHealthCheck() {
     if (this.currentTestShouldTimeout()) {
-        console.log("giveUpOnCurrentTest");
         this.giveUpOnCurrentTest();
     } else if (this.shouldUnload()) {
-        console.log("unload");
         this.unload();
     } else if (!this.seenSince(new Date(this.lastHealthCheck.getTime() - 2000))) {
-        console.log("sendPing");
         this.sendPing();
     }
     this.lastHealthCheck = new Date();
@@ -281,9 +277,7 @@ Agent.prototype.setTarget = function (target) {
         this.targetEmitter.add(target);
         this.debug("Added to Target", target.id);
 
-        console.log("NEW BROWSER ADDED TO TARGET!", this.target.tests.totalPending());
         if (this.target.tests.totalPending() > 0) {
-            console.log("hasPending!");
             // Tests are already available.
             this.next();
         }
@@ -322,7 +316,6 @@ Agent.prototype.nextURL = function () {
         this.currentTest.setExecuting(true);
         this.lastNavigate = new Date();
         url = test.getUrlForAgentId(this.id);
-        console.log("nextTest", test, url);
     } else {
         this.currentTest = null;
         // This agent is no longer a part of an Target.
@@ -367,7 +360,6 @@ Agent.prototype.queueSocketEmit = function (event, data) {
  * @return {Boolean} True if the browser is waiting, false otherwise
  */
 Agent.prototype.next = function () {
-    console.log("got Agent#next", (new Error()).stack);
     this.queueSocketEmit("navigate", this.nextURL());
     return !this.waiting;
 };
@@ -477,7 +469,6 @@ Agent.prototype.getTimeoutMilliseconds = function () {
  * @return {Boolean} True if the Agent is should unload, false otherwise.
  */
 Agent.prototype.shouldUnload = function () {
-    console.log("shouldUnload: unresponsivePings:", this.unresponsivePings);
     return this.unresponsivePings !== 0 && this.unresponsivePings > 3;
 };
 

--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -138,6 +138,13 @@ Agent.prototype.setupEvents = function () {
     // Cleanup.
     self.targetEmitter.on("complete", self.removeTarget.bind(self));
 
+    // Proxy to SockJS end()
+    self.socketEmitter.proxy("end");
+
+    self.socketEmitter.on("pong", function () {
+        self.ping();
+    });
+
     self.socketEmitter.on("close", function () {
         self.socketEmitter.remove(this.child);
     });
@@ -186,6 +193,8 @@ Agent.prototype.getName = function () {
 Agent.prototype.connect = function (socket) {
     var self = this,
         queuedEvents = self.socketEmitterQueue.slice();
+
+    self.ping();
 
     if (self.socketEmitter.children.length === 0) {
         self.socketEmitter.add(socket);
@@ -310,7 +319,8 @@ Agent.prototype.available = function () {
 Agent.prototype.unload = function () {
     this.debug("disconnecting agent! stack:", (new Error()).stack);
     this.connected = false;
-    this.seen = 0;
+    this.seen = new Date(0);
+    this.socketEmitter.end();
     this.emit("disconnect");
 };
 
@@ -319,8 +329,11 @@ Agent.prototype.unload = function () {
  * and advance to the next test.
  *
  * @method abort
+ * @deprecated
  */
 Agent.prototype.abort = function () {
+    // XXX: This is not called anywhere.
+    // TODO: Handle timeouts.
     this.emit("abort");
     this.emit("agentError", {
         message: "Agent timed out running test: " + this.currentUrl
@@ -343,6 +356,27 @@ Agent.prototype.ping = function () {
     this.emit("beat");
 };
 
+
+/**
+ * Ask the browser to respond: is it still connected?
+ *
+ * @method sendPing
+ */
+Agent.prototype.sendPing = function () {
+    this.queueSocketEmit("ping");
+};
+
+/**
+ * Determine if the browser was seen since the given time.
+ *
+ * @method seenSince
+ * @param {Date} since Last date.
+ * @return {Boolean} True if browser was seen, false otherwise.
+ */
+Agent.prototype.seenSince = function (since) {
+    return this.seen.getTime() > since.getTime();
+}
+
 /**
  * Check if this Agent is expired,
  * meaning that it has not connected
@@ -352,7 +386,7 @@ Agent.prototype.ping = function () {
  * @return {Boolean} True if the Agent is expired, false otherwise.
  */
 Agent.prototype.expired = function () {
-    var age = Date.now() - this.seen,
+    var age = Date.now() - this.seen.getTime(),
         ttl = this.ttl;
 
     if (this.target && this.target.testSpec) {

--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -38,6 +38,7 @@ function Agent(allAgents, registration) {
     this.name = parseUA(this.ua);
 
     this.seen = new Date();
+    this.lastNavigate = new Date(0);
     this.connected = true;
 
     this.target = null;
@@ -187,11 +188,11 @@ Agent.prototype.getName = function () {
 
 Agent.prototype.healthCheck = function agentHealthCheck() {
     if (!this.seenSince(new Date(this.lastHealthCheck.getTime() - 2000))) {
-        console.log("sending ping");
         this.sendPing();
     } else if (this.expired()) {
-        console.log("unloading since expired");
         this.unload();
+    } else if ((Date.now() - this.lastNavigate.getTime()) > this.getTimeoutMilliseconds()) {
+        this.abort();
     }
     this.lastHealthCheck = new Date();
 };
@@ -279,6 +280,7 @@ Agent.prototype.nextURL = function () {
 
     if (this.target) {
         url = this.target.nextURL(this.id);
+        this.lastNavigate = new Date();
     } else {
         // This agent is no longer a part of an Target.
         // This happens when a Batch is ended, esp.
@@ -359,15 +361,15 @@ Agent.prototype.unload = function () {
  */
 Agent.prototype.abort = function () {
     // XXX: This is not called anywhere.
-    // TODO: Handle timeouts.
     this.emit("abort");
     this.emit("agentError", {
         message: "Agent timed out running test: " + this.currentUrl
     });
     if (this.target) {
+        // TODO Mark to re-run on another Agent in this Target instead
         this.target.tests.getByUrl(this.currentUrl).setResults({});
     }
-    this.next(); //to next test
+    this.next();
 };
 
 /**
@@ -404,6 +406,23 @@ Agent.prototype.seenSince = function (since) {
 }
 
 /**
+ * Get the current timeout in milliseconds.
+ *
+ * @method getTimeoutMilliseconds
+ * @private
+ * @return {Number} Timeout in milliseconds.
+ */
+Agent.prototype.getTimeoutMilliseconds = function () {
+    var ttl = this.ttl;
+
+    if (this.target && this.target.testSpec) {
+        ttl = this.target.testSpec.getTimeoutMilliseconds();
+    }
+
+    return ttl;
+};
+
+/**
  * Check if this Agent is expired,
  * meaning that it has not connected
  * in a since the TTL.
@@ -413,12 +432,7 @@ Agent.prototype.seenSince = function (since) {
  */
 Agent.prototype.expired = function () {
     var age = Date.now() - this.seen.getTime(),
-        ttl = this.ttl;
-
-    if (this.target && this.target.testSpec) {
-        ttl = this.target.testSpec.getTimeoutMilliseconds();
-    }
-
+        ttl = this.getTimeoutMilliseconds();
     this.debug("expired check, age:", age, "ttl:", ttl);
     return age > ttl;
 };

--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -391,7 +391,6 @@ Agent.prototype.unload = function () {
  * @method giveUpOnCurrentTest
  */
 Agent.prototype.giveUpOnCurrentTest = function () {
-    // XXX: This is not called anywhere.
     this.emit("abort");
     this.emit("agentError", {
         message: "Agent timed out running test: " + this.currentUrl

--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -225,6 +225,8 @@ Agent.prototype.healthCheck = function agentHealthCheck() {
 Agent.prototype.currentTestShouldTimeout = function () {
     return (
         this.target &&
+        this.currentTest &&
+        !this.currentTest.isNull() &&
         this.unresponsiveCycles === 0 &&
         (Date.now() - this.lastNavigate.getTime()) > this.getTimeoutMilliseconds()
     );

--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -4,6 +4,8 @@ var util = require("util");
 var EventEmitter2 = require("../event-emitter");
 var EventYoshi = require("eventyoshi");
 
+var periodicRegistry = require("./periodic-registry").getRegistry();
+
 var parseUA = require("./ua");
 var makeURLFromComponents = require("./url-builder");
 
@@ -60,6 +62,9 @@ function Agent(allAgents, registration) {
     this.targetEmitter = new EventYoshi();
 
     this.setupEvents();
+
+    this.lastHealthCheck = new Date(0);
+    this.startPeriodicHealthCheck();
 }
 
 util.inherits(Agent, EventEmitter2);
@@ -178,6 +183,26 @@ Agent.prototype.setupEvents = function () {
  */
 Agent.prototype.getName = function () {
     return this.name + " from " + this.remoteAddress;
+};
+
+Agent.prototype.healthCheck = function agentHealthCheck() {
+    if (!this.seenSince(new Date(this.lastHealthCheck.getTime() - 2000))) {
+        console.log("sending ping");
+        this.sendPing();
+    } else if (this.expired()) {
+        console.log("unloading since expired");
+        this.unload();
+    }
+    this.lastHealthCheck = new Date();
+};
+
+Agent.prototype.startPeriodicHealthCheck = function () {
+    this.lastHealthCheck = new Date();
+    periodicRegistry.add("agent-health-" + this.id, this.healthCheck.bind(this), 1000);
+};
+
+Agent.prototype.stopPeriodicHealthCheck = function () {
+    periodicRegistry.remove("agent-health-" + this.id);
 };
 
 /**
@@ -318,6 +343,7 @@ Agent.prototype.available = function () {
  */
 Agent.prototype.unload = function () {
     this.debug("disconnecting agent! stack:", (new Error()).stack);
+    this.stopPeriodicHealthCheck();
     this.connected = false;
     this.seen = new Date(0);
     this.socketEmitter.end();

--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -425,14 +425,14 @@ Agent.prototype.getTimeoutMilliseconds = function () {
 /**
  * Check if this Agent is expired,
  * meaning that it has not connected
- * in a since the TTL.
+ * in the last minute.
  *
  * @method expired
  * @return {Boolean} True if the Agent is expired, false otherwise.
  */
 Agent.prototype.expired = function () {
     var age = Date.now() - this.seen.getTime(),
-        ttl = this.getTimeoutMilliseconds();
+        ttl = 60000;
     this.debug("expired check, age:", age, "ttl:", ttl);
     return age > ttl;
 };

--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -187,21 +187,6 @@ Agent.prototype.getName = function () {
     return this.name + " from " + this.remoteAddress;
 };
 
-// Browser starts.
-// 1. Browser disconnects.
-//    Normally fires unload and we never get here.
-//    NOP
-//
-// 2. Browser crashes.
-//    Stops responding to ping a few times.
-//    UNLOAD
-//
-// 3. Browser takes too long to run a test.
-//    Go to the next test.
-//    ABORT
-//
-// 4. Browser has not done anything in a while.
-//    PING
 Agent.prototype.healthCheck = function agentHealthCheck() {
     if (this.currentTestShouldTimeout()) {
         this.giveUpOnCurrentTest();
@@ -228,11 +213,19 @@ Agent.prototype.currentTestShouldTimeout = function () {
     );
 };
 
+/**
+ * @method startPeriodicHealthCheck
+ * @private
+ */
 Agent.prototype.startPeriodicHealthCheck = function () {
     this.lastHealthCheck = new Date();
     periodicRegistry.add("agent-health-" + this.id, this.healthCheck.bind(this), 1000);
 };
 
+/**
+ * @method stopPeriodicHealthCheck
+ * @private
+ */
 Agent.prototype.stopPeriodicHealthCheck = function () {
     periodicRegistry.remove("agent-health-" + this.id);
 };

--- a/lib/hub/all-agents.js
+++ b/lib/hub/all-agents.js
@@ -27,7 +27,7 @@ function AllAgents(hub) {
 util.inherits(AllAgents, EventEmitter2);
 
 AllAgents.prototype.bindTarget = function (target) {
-    console.log("bindTarget", target.id);
+    this.debug("bindTarget", target.id);
 
     target.pipeLog(this);
 

--- a/lib/hub/all-agents.js
+++ b/lib/hub/all-agents.js
@@ -40,6 +40,10 @@ function AllAgents(hub, ttl) {
         this._startReap();
     }
 
+    this._pinger = null;
+    this._lastPing = new Date(0);
+    this._lastReap = new Date(0);
+
     this.targetEmitter = new EventYoshi();
     this.bindEvents();
 }
@@ -122,7 +126,7 @@ AllAgents.prototype.syncReapInterval = function () {
  */
 //TODO Make this configurable
 //TODO This should probably be allowed to be passed to an Agent as it's TTL too. Not sure
-AllAgents.REAP_TTL = (10 * 1000); //Default reap timeout
+AllAgents.REAP_TTL = (4 * 1000); // Default reap timeout
 
 /**
  * TODO
@@ -138,6 +142,7 @@ AllAgents.prototype._startReap = function () {
         clearInterval(this._reap);
     }
     this._reap = setInterval(this.reap.bind(this), this.ttl);
+    this._pinger = setInterval(this.pinger.bind(this), 1000);
 };
 
 /**
@@ -147,11 +152,30 @@ AllAgents.prototype._startReap = function () {
  * @private
  */
 AllAgents.prototype.reap = function () {
-    this.getAgents().forEach(function (agent) {
-        if (agent.expired()) {
-            agent.abort();
+    var self = this;
+    self.getAgents().forEach(function (agent) {
+        if (!agent.seenSince(self._lastReap)) {
+            agent.unload();
         }
     });
+    self._lastReap = new Date(Date.now() - 1000);
+};
+
+/**
+ * Pings browsers that have not been seen since
+ * the last time this function ran.
+ *
+ * @method pinger
+ * @private
+ */
+AllAgents.prototype.pinger = function () {
+    var self = this;
+    self.getAgents().forEach(function (agent) {
+        if (!agent.seenSince(self._lastPing)) {
+            agent.sendPing();
+        }
+    });
+    self._lastPing = new Date(Date.now() - 1000);
 };
 
 /**

--- a/lib/hub/all-agents.js
+++ b/lib/hub/all-agents.js
@@ -9,57 +9,28 @@ var Target = require("./target");
 
 var makeURLFromComponents = require("./url-builder");
 
-var REAP = true;
-if (process.env.YETI_NO_TIMEOUT) {
-    console.warn("Yeti AllAgents: Disabling agent reaping");
-    REAP = false;
-}
-
 /**
  * @class AllAgents
  * @constructor
  * @inherits EventEmitter2
  * @param {Hub} hub Hub associated with this object.
- * @param {Number} ttl TTL for associated Agents.
  */
-function AllAgents(hub, ttl) {
+function AllAgents(hub) {
     this.hub = hub;
     this.agents = {};
     this.boundTargets = {};
     EventEmitter2.call(this, {
         verbose: true
     });
-
-    this.ttl = ttl || AllAgents.REAP_TTL;
-
-    this.defaults = {
-        ttl: this.ttl
-    };
-
-    if (REAP) {
-        this._startReap();
-    }
-
-    this._pinger = null;
-    this._lastPing = new Date(0);
-    this._lastReap = new Date(0);
-
-    this.targetEmitter = new EventYoshi();
-    this.bindEvents();
 }
 
 util.inherits(AllAgents, EventEmitter2);
-
-AllAgents.prototype.bindEvents = function () {
-    this.targetEmitter.on("dispatch", this.syncReapInterval.bind(this));
-};
 
 AllAgents.prototype.bindTarget = function (target) {
     this.debug("bindTarget", target.id);
 
     target.pipeLog(this);
 
-    this.targetEmitter.add(target);
     target.on("complete", this.unbindTarget.bind(this, target));
 
     this.boundTargets[target.id] = target;
@@ -68,114 +39,6 @@ AllAgents.prototype.bindTarget = function (target) {
 
 AllAgents.prototype.unbindTarget = function (target) {
     delete this.boundTargets[target.id];
-
-    this.targetEmitter.remove(target);
-
-    this.syncReapInterval(target);
-};
-
-AllAgents.prototype.syncReapInterval = function () {
-    var ttl = this.ttl,
-        baseline = this.defaults.ttl,
-        boundTargets = this.boundTargets,
-        runningValues = [],
-        minValue,
-        maxValue,
-        newInterval;
-
-    Object.keys(boundTargets).forEach(function (targetId) {
-        runningValues.push(boundTargets[targetId].ttl);
-    });
-
-    if (runningValues.length) {
-
-        minValue = runningValues.reduce(function (a, b) {
-            return Math.min(a, b);
-        });
-
-        if (minValue < ttl) {
-            newInterval = minValue;
-        } else {
-            maxValue = runningValues.reduce(function (a, b) {
-                return Math.max(a, b);
-            });
-
-            if (maxValue < baseline) {
-                newInterval = maxValue;
-            } else {
-                newInterval = baseline;
-            }
-        }
-
-    } else {
-        newInterval = baseline;
-    }
-
-    this.debug("syncReapInterval new =", newInterval, "old =", this.ttl);
-
-    if (newInterval !== this.ttl) {
-        this.ttl = newInterval;
-        this._startReap();
-    }
-};
-
-/**
- * @property REAP_TTL
- * @type Number
- * @default 45000
- */
-//TODO Make this configurable
-//TODO This should probably be allowed to be passed to an Agent as it's TTL too. Not sure
-AllAgents.REAP_TTL = (4 * 1000); // Default reap timeout
-
-/**
- * TODO
- *
- * @method _startReap
- * @private
- */
-//TODO this needs to be destroyed at some point, just not sure where (`agentManager.destroy()` maybe)
-AllAgents.prototype._startReap = function () {
-    if (this._reap) {
-        this.debug("About to reschedule reap to ttl =",
-                this.ttl + ", clearing old interval", this._reap);
-        clearInterval(this._reap);
-    }
-    this._reap = setInterval(this.reap.bind(this), this.ttl);
-    this._pinger = setInterval(this.pinger.bind(this), 1000);
-};
-
-/**
- * TODO
- *
- * @method reap
- * @private
- */
-AllAgents.prototype.reap = function () {
-    var self = this;
-    self.getAgents().forEach(function (agent) {
-        if (!agent.seenSince(self._lastReap)) {
-            agent.unload();
-        }
-    });
-    self._lastReap = new Date(Date.now() - 1000);
-};
-
-/**
- * Pings browsers that have not been seen since
- * the last time this function ran.
- *
- * @method pinger
- * @private
- */
-AllAgents.prototype.pinger = function () {
-    var self = this;
-    self.getAgents().forEach(function (agent) {
-        if (!agent.seenSince(self._lastPing)) {
-            agent.sendPing();
-        }
-    });
-    self._lastPing = new Date(Date.now() - 1000);
 };
 
 /**
@@ -226,7 +89,6 @@ AllAgents.prototype.createTargetsForAgents = function (agents) {
 
     return targets;
 };
-
 
 /**
  * Get all Agents.

--- a/lib/hub/all-agents.js
+++ b/lib/hub/all-agents.js
@@ -27,7 +27,7 @@ function AllAgents(hub) {
 util.inherits(AllAgents, EventEmitter2);
 
 AllAgents.prototype.bindTarget = function (target) {
-    this.debug("bindTarget", target.id);
+    console.log("bindTarget", target.id);
 
     target.pipeLog(this);
 

--- a/lib/hub/batch.js
+++ b/lib/hub/batch.js
@@ -253,6 +253,8 @@ Batch.prototype.dispatch = function () {
 
         self.targetEmitter.add(target);
 
+        allAgents.bindTarget(target);
+
         target.dispatch(self.id, self.spec);
     });
 

--- a/lib/hub/null-test.js
+++ b/lib/hub/null-test.js
@@ -37,4 +37,22 @@ NullTest.prototype.getUrlForAgentId = function (agentId) {
     return this.mountpoint + "agent/" + agentId;
 };
 
+/**
+ * Mark if this test is being worked on by a browser.
+ * No-op.
+ *
+ * @method setExecuting
+ */
+NullTest.prototype.setExecuting = function () {}; // NOOP
+
+/**
+ * Determine if this test is being worked on by a browser.
+ *
+ * @method isExecuting
+ * @return {Boolean} True if executing, false otherwise.
+ */
+NullTest.prototype.isExecuting = function () {
+    return false;
+};
+
 module.exports = NullTest;

--- a/lib/hub/null-test.js
+++ b/lib/hub/null-test.js
@@ -55,4 +55,15 @@ NullTest.prototype.isExecuting = function () {
     return false;
 };
 
+/**
+ * Determine if this is the NullTest.
+ *
+ * @method isNull
+ * @override
+ * @return {Boolean} True.
+ */
+NullTest.prototype.isNull = function () {
+    return true;
+};
+
 module.exports = NullTest;

--- a/lib/hub/null-tests.js
+++ b/lib/hub/null-tests.js
@@ -67,4 +67,15 @@ NullTests.prototype.didComplete = function () {
     return true;
 };
 
+/**
+ * Get the amount of tests waiting to be sent to a browser.
+ *
+ * @method totalPending
+ * @override
+ * @return {Number} Zero.
+ */
+NullTests.prototype.totalPending = function () {
+    return 0
+};
+
 module.exports = NullTests;

--- a/lib/hub/null-tests.js
+++ b/lib/hub/null-tests.js
@@ -75,7 +75,7 @@ NullTests.prototype.didComplete = function () {
  * @return {Number} Zero.
  */
 NullTests.prototype.totalPending = function () {
-    return 0
+    return 0;
 };
 
 module.exports = NullTests;

--- a/lib/hub/null-tests.js
+++ b/lib/hub/null-tests.js
@@ -43,17 +43,6 @@ NullTests.createForMountpoint = function (mountpoint) {
 /**
  * Return the NullTest.
  *
- * @method peek
- * @override
- * @return {NullTest} Instance of NullTest for our mountpoint.
- */
-NullTests.prototype.peek = function () {
-    return this.nullTest;
-};
-
-/**
- * Return the NullTest.
- *
  * TODO: Refactor to make this override not needed.
  *
  * @method next
@@ -61,7 +50,7 @@ NullTests.prototype.peek = function () {
  * @return {NullTest} Instance of NullTest for our mountpoint.
  */
 NullTests.prototype.next = function () {
-    return this.peek();
+    return this.nullTest;
 };
 
 /**

--- a/lib/hub/periodic-registry.js
+++ b/lib/hub/periodic-registry.js
@@ -1,0 +1,186 @@
+"use strict";
+
+var registry,
+    proto;
+
+/**
+ * Registry of functions to run periodically.
+ *
+ * @class PeriodicRegistry
+ * @constructor
+ */
+function PeriodicRegistry() {
+    this.children = {};
+    this.runTimeout = null;
+    this.scheduleEveryMilliseconds = null;
+}
+
+/**
+ * Repository of functions and their last run time.
+ *
+ * @property children
+ * @type {Object}
+ * @private
+ */
+
+/**
+ * Timeout ID of the currently scheduled setTimeout
+ * for `this.run`.
+ *
+ * @property runTimeout
+ * @type {String}
+ * @private
+ */
+
+/**
+ * Time in milliseconds between `this.run` calls.
+ *
+ * @property scheduleEveryMilliseconds
+ * @type {Number}
+ * @private
+ */
+
+/**
+ * Get the singleton.
+ *
+ * @method getRegistry
+ * @static
+ * @return {PeriodicRegistry} Registry singleton.
+ */
+PeriodicRegistry.getRegistry = function () {
+    if (!registry) { registry = new PeriodicRegistry(); }
+    return registry;
+};
+
+proto = PeriodicRegistry.prototype;
+
+/**
+ * Get all repository objects as an array.
+ *
+ * @method getAllAsArray
+ * @return {Object[]} Array of repository objects.
+ */
+proto.getAllAsArray = function () {
+    var self = this,
+        children = [];
+    Object.keys(self.children).forEach(function (key) {
+        children.push(self.children[key]);
+    });
+    return children;
+};
+
+/**
+ * Determine if functions in this repository need to run,
+ * then run them. Called by our setTimeout.
+ *
+ * @method run
+ * @private
+ */
+proto.run = function periodicRegistryRunner() {
+    var now = new Date();
+    this.getAllAsArray().forEach(function (child) {
+        var timeSinceLastRun = now.getTime() - child.lastRun.getTime();
+        console.log(child.fn.name, "last ran", child.lastRun, "time since", timeSinceLastRun, "interval", child.interval);
+        if (timeSinceLastRun > child.interval) {
+            console.log("Run!");
+            child.fn();
+            child.lastRun = now;
+        }
+    });
+    this.start();
+};
+
+/**
+ * Start running registered functions periodically.
+ *
+ * @method start
+ */
+proto.start = function () {
+    if (this.runTimeout) { this.stop(); }
+    if (!this.getAllAsArray().length) { return; }
+    console.log("Scheduling runner for", this.scheduleEveryMilliseconds);
+    this.runTimeout = setTimeout(
+        this.run.bind(this),
+        this.scheduleEveryMilliseconds
+    );
+};
+
+/**
+ * Stop running registered functions periodically.
+ *
+ * @method stop
+ */
+proto.stop = function () {
+    if (!this.runTimeout) { return; }
+    clearTimeout(this.runTimeout);
+    this.runTimeout = null;
+};
+
+/**
+ * Get all intervals for registered functions as an array.
+ *
+ * @method getAllIntervals
+ * @return {Number[]} Array of intervals in milliseconds.
+ */
+proto.getAllIntervals = function () {
+    var intervals = [];
+    this.getAllAsArray().forEach(function (child) {
+        intervals.push(child.interval);
+    });
+    return intervals;
+};
+
+/**
+ * Reschedule the periodic runner given the intervals
+ * of the registered functions. Starts running if
+ * it's not already.
+ *
+ * @method syncIntervalsAndStart
+ * @private
+ */
+proto.syncIntervalsAndStart = function () {
+    var intervals = this.getAllIntervals(),
+        minInterval;
+
+    if (!intervals.length) { return; }
+
+    minInterval = intervals.reduce(function (prev, next) {
+        return Math.min(prev, next);
+    });
+
+    this.scheduleEveryMilliseconds = minInterval;
+    this.start();
+};
+
+/**
+ * Add a function to the registry.
+ *
+ * @method add
+ * @param {String} id Reference for the registered function.
+ *                    Can be used later to remove it.
+ * @param {Function} fn Function. Must be bound to the correct context.
+ * @param {Number} interval Interval to run this function in milliseconds.
+ */
+proto.add = function (id, fn, interval) {
+    this.children[id] = {
+        fn: fn,
+        interval: interval,
+        lastRun: new Date(0)
+    };
+    this.syncIntervalsAndStart();
+};
+
+/**
+ * Remove a function from the registry.
+ *
+ * @method remove
+ * @param {String} id Reference given when adding the function.
+ */
+proto.remove = function (id) {
+    if (id in this.children) {
+        delete this.children[id];
+        this.syncIntervalsAndStart();
+    }
+};
+
+module.exports = PeriodicRegistry;

--- a/lib/hub/periodic-registry.js
+++ b/lib/hub/periodic-registry.js
@@ -80,9 +80,7 @@ proto.run = function periodicRegistryRunner() {
     var now = new Date();
     this.getAllAsArray().forEach(function (child) {
         var timeSinceLastRun = now.getTime() - child.lastRun.getTime();
-        console.log(child.fn.name, "last ran", child.lastRun, "time since", timeSinceLastRun, "interval", child.interval);
         if (timeSinceLastRun > child.interval) {
-            console.log("Run!");
             child.fn();
             child.lastRun = now;
         }
@@ -98,7 +96,6 @@ proto.run = function periodicRegistryRunner() {
 proto.start = function () {
     if (this.runTimeout) { this.stop(); }
     if (!this.getAllAsArray().length) { return; }
-    console.log("Scheduling runner for", this.scheduleEveryMilliseconds);
     this.runTimeout = setTimeout(
         this.run.bind(this),
         this.scheduleEveryMilliseconds

--- a/lib/hub/target.js
+++ b/lib/hub/target.js
@@ -141,11 +141,7 @@ Target.prototype.nextTest = function (agentId) {
         current: this.tests.totalSubmitted() - this.tests.totalPending()
     });
 
-    //this.currentTest = this.tests.next();
-    //this.currentTest.isExecuting(true);
-
     return this.tests.next();
-    // .getUrlForAgentId(agentId);
 };
 
 /**

--- a/lib/hub/target.js
+++ b/lib/hub/target.js
@@ -154,6 +154,7 @@ Target.prototype.nextURL = function (agentId) {
 Target.prototype.dispatch = function (batchId, testSpec) {
     this.batchId = batchId;
     this.testSpec = testSpec;
+    this.ttl = testSpec.timeout * 1000;
     this.tests = testSpec.createTests();
     this.debug("Emit dispatch for batchId", batchId);
     this.emit("dispatch", batchId);

--- a/lib/hub/target.js
+++ b/lib/hub/target.js
@@ -104,7 +104,9 @@ Target.prototype.setupEvents = function () {
     var self = this;
 
     self.agentEmitter.on("results", function (data) {
-        self.tests.getByUrl(data.url).setResults(data);
+        var test = self.tests.getByUrl(data.url);
+        test.setResults(data);
+        test.isExecuting(false);
         self.emit("results", data);
     });
     self.agentEmitter.on("scriptError", self.emit.bind(self, "scriptError"));
@@ -118,19 +120,19 @@ Target.prototype.setupEvents = function () {
 };
 
 /**
- * Get the value for the next URL,
- * removing it from `this.urlQueue`.
+ * Get the next Test.
  *
  * Fires our complete event when no more
  * URLs are in the queue, then returns
  * the capture page URL.
  *
- * @method nextURL
+ * @method nextTest
  * @param {String} agentId Agent ID.
- * @return {String} Next test URL, or capture page URL.
+ * @return {Test} Next test. May be a NullTest if we're done.
  */
-Target.prototype.nextURL = function (agentId) {
+Target.prototype.nextTest = function (agentId) {
     if (this.tests.didComplete()) {
+        console.log("complete!!");
         this.emit("complete");
         this.batchId = null;
     }
@@ -140,7 +142,11 @@ Target.prototype.nextURL = function (agentId) {
         current: this.tests.totalSubmitted() - this.tests.totalPending()
     });
 
-    return this.tests.next().getUrlForAgentId(agentId);
+    //this.currentTest = this.tests.next();
+    //this.currentTest.isExecuting(true);
+
+    return this.tests.next();
+    // .getUrlForAgentId(agentId);
 };
 
 /**

--- a/lib/hub/target.js
+++ b/lib/hub/target.js
@@ -132,7 +132,6 @@ Target.prototype.setupEvents = function () {
  */
 Target.prototype.nextTest = function (agentId) {
     if (this.tests.didComplete()) {
-        console.log("complete!!");
         this.emit("complete");
         this.batchId = null;
     }

--- a/lib/hub/test-specification.js
+++ b/lib/hub/test-specification.js
@@ -13,7 +13,7 @@ var Tests = require("./tests");
  * @param {String[]} spec.tests Tests. Either relative paths to `spec.basedir` or URL pathnames.
  * @param {String} [spec.basedir] Root path for serving tests. Required if `useProxy` is true or not provided.
  * @param {String} [spec.query] Query string additions for test URLs.
- * @param {Number} [spec.timeout] Per-test timeout in seconds. Default is 45 seconds.
+ * @param {Number} [spec.timeout] Per-test timeout in seconds. Default is 5 minutes.
  *                                  If no activity occurs before the timeout, the next test is loaded.
  * @param {Boolean} [spec.useProxy] True if tests are filenames to proxy to the Hub.
  *                           false if they are literal URL pathnames.
@@ -30,7 +30,7 @@ function TestSpecification(spec) {
     this.mountpount = this.setMountpoint(spec.mountpoint);
 }
 
-TestSpecification.DEFAULT_TIMEOUT = 45;
+TestSpecification.DEFAULT_TIMEOUT = 300; // 5 minutes
 
 /**
  * Creates a new TestSpecification with no tests.

--- a/lib/hub/test.js
+++ b/lib/hub/test.js
@@ -22,6 +22,7 @@ function Test(options) {
     this.batchId = options.batchId;
     this.mountpoint = options.mountpoint;
     this.results = null;
+    this.executing = false;
 }
 
 /**
@@ -49,6 +50,27 @@ Test.prototype.getUrlForAgentId = function (agentId) {
  */
 Test.prototype.setResults = function (results) {
     this.results = results;
+};
+
+/**
+ * Mark if this test is being worked on by a browser.
+ *
+ * @method setExecuting
+ * @param {Boolean} executing True if executing, false otherwise.
+ */
+Test.prototype.setExecuting = function (executing) {
+    this.executing = !!executing;
+    console.log("setExecuting for location", this.location, this.executing);
+};
+
+/**
+ * Determine if this test is being worked on by a browser.
+ *
+ * @method isExecuting
+ * @return {Boolean} True if executing, false otherwise.
+ */
+Test.prototype.isExecuting = function () {
+    return this.executing;
 };
 
 module.exports = Test;

--- a/lib/hub/test.js
+++ b/lib/hub/test.js
@@ -60,7 +60,6 @@ Test.prototype.setResults = function (results) {
  */
 Test.prototype.setExecuting = function (executing) {
     this.executing = !!executing;
-    console.log("setExecuting for location", this.location, this.executing);
 };
 
 /**

--- a/lib/hub/test.js
+++ b/lib/hub/test.js
@@ -73,4 +73,14 @@ Test.prototype.isExecuting = function () {
     return this.executing;
 };
 
+/**
+ * Determine if this is the NullTest.
+ *
+ * @method isNull
+ * @return {Boolean} False.
+ */
+Test.prototype.isNull = function () {
+    return false;
+};
+
 module.exports = Test;

--- a/lib/hub/tests.js
+++ b/lib/hub/tests.js
@@ -67,6 +67,7 @@ Tests.prototype.getTestsWithoutResults = function () {
     var self = this,
         testsWithoutResults = [];
 
+    console.log("gTWA", self.children, self, this);
     Object.keys(self.children).forEach(function (location) {
         var test = self.children[location];
 
@@ -74,6 +75,19 @@ Tests.prototype.getTestsWithoutResults = function () {
     });
 
     return testsWithoutResults;
+};
+
+/**
+ * Get an array of Test objects that do not have results
+ * and are not being ran in a browser now.
+ *
+ * @method getPendingTests
+ * @return {Test[]} Test objects pending.
+ */
+Tests.prototype.getPendingTests = function () {
+    return this.getTestsWithoutResults().filter(function (test) {
+        return !test.isExecuting();
+    });
 };
 
 /**
@@ -133,7 +147,7 @@ Tests.prototype.totalSubmitted = function () {
  * @return {Number} Number of Tests.
  */
 Tests.prototype.totalPending = function () {
-    return this.getTestsWithoutResults().length;
+    return this.getPendingTests().length;
 };
 
 /**
@@ -143,8 +157,9 @@ Tests.prototype.totalPending = function () {
  * @return {Test} Next Test in queue, or NullTest if no Test objects are left.
  */
 Tests.prototype.next = function () {
-    var test = this.getTestsWithoutResults().shift();
+    var test = this.getPendingTests().shift();
     if (!test) { test = this.nullTest; }
+    console.log("Tests#next: location:", test.location);
     return test;
 };
 

--- a/lib/hub/tests.js
+++ b/lib/hub/tests.js
@@ -67,7 +67,6 @@ Tests.prototype.getTestsWithoutResults = function () {
     var self = this,
         testsWithoutResults = [];
 
-    console.log("gTWA", self.children, self, this);
     Object.keys(self.children).forEach(function (location) {
         var test = self.children[location];
 
@@ -159,7 +158,6 @@ Tests.prototype.totalPending = function () {
 Tests.prototype.next = function () {
     var test = this.getPendingTests().shift();
     if (!test) { test = this.nullTest; }
-    console.log("Tests#next: location:", test.location);
     return test;
 };
 

--- a/lib/hub/tests.js
+++ b/lib/hub/tests.js
@@ -18,7 +18,6 @@ var NullTest = require("./null-test");
 function Tests(spec) {
     this.children = {};
     this.initializeFromSpecification(spec);
-    this.waitingToStart = Object.keys(this.children);
 
     this.nullTest = new NullTest(spec);
 }
@@ -134,30 +133,7 @@ Tests.prototype.totalSubmitted = function () {
  * @return {Number} Number of Tests.
  */
 Tests.prototype.totalPending = function () {
-    return this.waitingToStart.length;
-};
-
-/**
- * Get a test waiting to start at the given index.
- *
- * @method queuedTestAtIndex
- * @param {Number} index
- * @return {Test} Test at the given queue index, or NullTest if not defined.
- */
-Tests.prototype.queuedTestAtIndex = function (index) {
-    var test = this.children[this.waitingToStart[index]];
-    if (!test) { test = this.nullTest; }
-    return test;
-};
-
-/**
- * Get the next Test in the queue.
- *
- * @method peek
- * @return {Test} Next Test in queue, or NullTest if no Test objects are left.
- */
-Tests.prototype.peek = function () {
-    return this.queuedTestAtIndex(0);
+    return this.getTestsWithoutResults().length;
 };
 
 /**
@@ -167,9 +143,9 @@ Tests.prototype.peek = function () {
  * @return {Test} Next Test in queue, or NullTest if no Test objects are left.
  */
 Tests.prototype.next = function () {
-    var nextTest = this.peek();
-    this.waitingToStart.shift();
-    return nextTest;
+    var test = this.getTestsWithoutResults().shift();
+    if (!test) { test = this.nullTest; }
+    return test;
 };
 
 module.exports = Tests;

--- a/lib/hub/view/public/tempest.js
+++ b/lib/hub/view/public/tempest.js
@@ -489,9 +489,10 @@ YUI.add("tempest", function (Y, name) {
             self.cancelWatchdog();
 
             Y.later(timeout, null, function () {
+                self.destroy();
                 Y.config.doc.location.href = test;
             });
-            self.destroy();
+            self.setStatus("Moving to the next test...");
         });
 
         self.tower.on("listening", function onListening() {

--- a/lib/hub/view/public/tempest.js
+++ b/lib/hub/view/public/tempest.js
@@ -268,6 +268,15 @@ YUI.add("tempest", function (Y, name) {
         this.watchdogTimeout = null;
 
         /**
+         * Timeout for page navigation.
+         *
+         * @property navigateTimeout
+         * @private
+         * @type Object|null
+         */
+        this.navigateTimeout = null;
+
+        /**
          * Page destruction is pending.
          *
          * @property destroySoon
@@ -285,6 +294,9 @@ YUI.add("tempest", function (Y, name) {
          */
         this.scanning = false;
 
+        this.lastPong = new Date();
+        this.lastWatchdogCheck = new Date();
+
         this.setupWindowHandlers();
 
         this.automation = new Y.AutomationGroup();
@@ -297,11 +309,11 @@ YUI.add("tempest", function (Y, name) {
     /**
      * Time to wait before moving to the next test.
      *
-     * @property navigateTimeout
+     * @property navigateTimeoutMilliseconds
      * @default 10
      * @type Number
      */
-    ATTRS.navigateTimeout = {
+    ATTRS.navigateTimeoutMilliseconds = {
         valueFn: function () {
             if (Y.UA.ie && Y.UA.ie <= 7) {
                 return 5000;
@@ -470,25 +482,36 @@ YUI.add("tempest", function (Y, name) {
         this.connectWithHandshake();
     };
 
+    proto.deliverResultsIfNeeded = function () {
+        if (this.get("results")) {
+            // We have results to re-deliver.
+            this.debug("Re-delivering results.");
+            this.tower.emit("results", results);
+        }
+    };
+
     proto.setupTowerHandlers = function () {
         var self = this;
 
         self.tower.on("ping", function onPing() {
+            self.lastPong = new Date();
             self.tower.emit("pong");
-
-            if (self.get("results")) {
-                // We have results to re-deliver.
-                self.debug("Re-delivering results.");
-                self.tower.emit("results", results);
-            }
+            self.debug("WTF?", self.get("results"));
+            self.deliverResultsIfNeeded();
         });
 
         self.tower.on("navigate", function onNavigate(test) {
-            var timeout = self.get("navigateTimeout");
+            var timeout = self.get("navigateTimeoutMilliseconds");
 
             self.cancelWatchdog();
 
-            Y.later(timeout, null, function () {
+            if (self.navigateTimeout) {
+                // Yeti server wants us on another page
+                // because our navigateTimeout is so long.
+                self.navigateTimeout.cancel();
+            }
+
+            self.navigateTimeout = Y.later(timeout, null, function () {
                 self.destroy();
                 Y.config.doc.location.href = test;
             });
@@ -513,6 +536,20 @@ YUI.add("tempest", function (Y, name) {
                 document.cookie = "yeti-agent=" + self.get("agentId") +
                     ";path=/;expires=Sat, 10 Mar 2029 08:00:00 GMT";
             }
+            self.deliverResultsIfNeeded();
+/*
+            (function watchdog() {
+                self.debug("Begin check...");
+                self.debug("Watchdog check...", self.lastPong.getTime(), self.lastWatchdogCheck.getTime(), self.lastPong.getTime() - self.lastWatchdogCheck.getTime());
+                var delta = self.lastPong.getTime() - self.lastWatchdogCheck.getTime(); 
+                if (delta > 10000 || delta < 0) {
+                    self.debug("Watchdog failure!");
+                    Y.config.win.location.href = Y.config.win.location.href; 
+                }
+                self.lastWatchdogCheck = new Date();
+                self.watchdogTimeout = Y.later(5000, null, watchdog);
+            }());
+*/
         });
 
         self.tower.on("close", function onClose() {

--- a/lib/hub/view/public/tempest.js
+++ b/lib/hub/view/public/tempest.js
@@ -190,7 +190,7 @@ YUI.add("tempest-hubclient", function (Y, name) {
             emitter.messageQueue = this.transientMessageQueue;
             this.transientMessageQueue = [];
             emitter.on("open", function hubClientFlusher() {
-               emitter.flushQueue();
+                emitter.flushQueue();
             });
         }
 
@@ -542,10 +542,10 @@ YUI.add("tempest", function (Y, name) {
             (function watchdog() {
                 self.debug("Begin check...");
                 self.debug("Watchdog check...", self.lastPong.getTime(), self.lastWatchdogCheck.getTime(), self.lastPong.getTime() - self.lastWatchdogCheck.getTime());
-                var delta = self.lastPong.getTime() - self.lastWatchdogCheck.getTime(); 
+                var delta = self.lastPong.getTime() - self.lastWatchdogCheck.getTime();
                 if (delta > 10000 || delta < 0) {
                     self.debug("Watchdog failure!");
-                    Y.config.win.location.href = Y.config.win.location.href; 
+                    Y.config.win.location.href = Y.config.win.location.href;
                 }
                 self.lastWatchdogCheck = new Date();
                 self.watchdogTimeout = Y.later(5000, null, watchdog);

--- a/lib/hub/view/public/tempest.js
+++ b/lib/hub/view/public/tempest.js
@@ -474,12 +474,10 @@ YUI.add("tempest", function (Y, name) {
 
             self.cancelWatchdog();
 
-            self.destroySoon = true;
-
             Y.later(timeout, null, function () {
-                self.destroy();
                 Y.config.doc.location.href = test;
             });
+            self.destroy();
         });
 
         self.tower.on("listening", function onListening() {

--- a/lib/hub/view/public/tempest.js
+++ b/lib/hub/view/public/tempest.js
@@ -303,7 +303,9 @@ YUI.add("tempest", function (Y, name) {
      */
     ATTRS.navigateTimeout = {
         valueFn: function () {
-            if (Y.UA.ie && Y.UA.ie <= 6) {
+            if (Y.UA.ie && Y.UA.ie <= 7) {
+                return 5000;
+            } else if (Y.UA.android) {
                 return 1000;
             }
             return 10;

--- a/lib/hub/view/public/tempest.js
+++ b/lib/hub/view/public/tempest.js
@@ -355,6 +355,14 @@ YUI.add("tempest", function (Y, name) {
         value: false
     };
 
+    /**
+     * @property results
+     * @type Object
+     */
+    ATTRS.results = {
+        value: null
+    };
+
     Y.extend(InjectedDriver, Y.TempestBaseCore);
     Y.augment(InjectedDriver, Y.AttributeEvents);
 
@@ -467,6 +475,12 @@ YUI.add("tempest", function (Y, name) {
 
         self.tower.on("ping", function onPing() {
             self.tower.emit("pong");
+
+            if (self.get("results")) {
+                // We have results to re-deliver.
+                self.debug("Re-delivering results.");
+                self.tower.emit("results", results);
+            }
         });
 
         self.tower.on("navigate", function onNavigate(test) {
@@ -526,6 +540,7 @@ YUI.add("tempest", function (Y, name) {
 
         self.automation.on("results", function (results) {
             self.beat();
+            self.set("results", results);
             self.tower.emit("results", results);
         });
 

--- a/lib/hub/view/public/tempest.js
+++ b/lib/hub/view/public/tempest.js
@@ -49,6 +49,19 @@ YUI.add("tempest-hubclient", function (Y, name) {
          * @type SimpleEvents
          */
         this.tower = null;
+
+        /**
+         * Queued events from previous connection.
+         * Set when `this.sock` disconnects,
+         * moved to the new instance of `this.sock`.
+         *
+         * @property transientMessageQueue
+         * @protected
+         * @type Array
+         */
+        this.transientMessageQueue = [];
+
+        this.destroyed = false;
     }
 
     HubClient.NAME = "hubClient";
@@ -141,8 +154,15 @@ YUI.add("tempest-hubclient", function (Y, name) {
     };
 
     proto.destroyConnection = function () {
+        if (this.destroyed) { return; }
+        this.debug("destroying connection", this.tower);
+        if (this.tower && this.tower.messageQueue.length) {
+            this.transientMessageQueue = this.transientMessageQueue.concat(this.tower.messageQueue);
+            this.debug("Transient MQ has", this.transientMessageQueue.length, "events");
+        }
         this.tower = null;
         this.sock = null;
+        this.destroyed = true;
     };
 
     /**
@@ -151,16 +171,32 @@ YUI.add("tempest-hubclient", function (Y, name) {
      * @method connectWithHandshake
      */
     proto.connect = function () {
+        var emitter,
+            queueLength = this.transientMessageQueue.length;
+
         this.debug("Connecting to", this.get("sockUrl"));
 
         this.sock = new SockJS(this.get("sockUrl"), null, {
             protocols_whitelist: this.get("protocols")
         });
 
-        return new SimpleEvents(
+        emitter = new SimpleEvents(
             this.sock,
             Y.bind(this.debug, this, "[SimpleEvents]")
         );
+
+        if (queueLength) {
+            this.debug("Moving", queueLength, "messages to the new queue");
+            emitter.messageQueue = this.transientMessageQueue;
+            this.transientMessageQueue = [];
+            emitter.on("open", function hubClientFlusher() {
+               emitter.flushQueue();
+            });
+        }
+
+        this.tower = emitter;
+
+        return emitter;
     };
 
     proto.isStreamingProtocol = function () {
@@ -396,7 +432,6 @@ YUI.add("tempest", function (Y, name) {
     };
 
     proto.syncUI = function () {
-        this.debug("status: " + this.get("status"));
         if (this.get("captureOnly")) {
             document.getElementById("test").innerHTML = this.get("status");
         }
@@ -418,6 +453,11 @@ YUI.add("tempest", function (Y, name) {
     proto.setStatus = function (message) {
         this.set("status", message);
         this.syncUI();
+    };
+
+    proto.reconnect = function () {
+        this.hub.destroyConnection();
+        this.connectWithHandshake();
     };
 
     proto.setupTowerHandlers = function () {
@@ -462,10 +502,10 @@ YUI.add("tempest", function (Y, name) {
             }
 
             self.cancelWatchdog();
-            self.hub.destroyConnection();
             self.debug("Closed, reconnecting in 5 sec.");
             self.setStatus("Closed, reconnecting in 5 seconds.");
-            Y.later(5000, self, self.connectWithHandshake);
+            self.tower.queueUntil("open"); // collect events for reconnecting
+            Y.later(5000, self, self.reconnect);
         });
     };
 

--- a/lib/hub/view/public/tempest.js
+++ b/lib/hub/view/public/tempest.js
@@ -484,7 +484,9 @@ YUI.add("tempest", function (Y, name) {
 
     proto.deliverResultsIfNeeded = function () {
         var results = this.get("results");
-        if (results) {
+        // Do not deliver results again if we already
+        // plan to navigate to the next test.
+        if (results && !this.navigateTimeout) {
             // We have results to re-deliver.
             this.debug("Re-delivering results.");
             this.tower.emit("results", results);

--- a/lib/hub/view/public/tempest.js
+++ b/lib/hub/view/public/tempest.js
@@ -463,6 +463,10 @@ YUI.add("tempest", function (Y, name) {
     proto.setupTowerHandlers = function () {
         var self = this;
 
+        self.tower.on("ping", function onPing() {
+            self.tower.emit("pong");
+        });
+
         self.tower.on("navigate", function onNavigate(test) {
             var timeout = self.get("navigateTimeout");
 

--- a/lib/hub/view/public/tempest.js
+++ b/lib/hub/view/public/tempest.js
@@ -483,7 +483,8 @@ YUI.add("tempest", function (Y, name) {
     };
 
     proto.deliverResultsIfNeeded = function () {
-        if (this.get("results")) {
+        var results = this.get("results");
+        if (results) {
             // We have results to re-deliver.
             this.debug("Re-delivering results.");
             this.tower.emit("results", results);

--- a/lib/hub/view/public/tempest.js
+++ b/lib/hub/view/public/tempest.js
@@ -259,15 +259,6 @@ YUI.add("tempest", function (Y, name) {
         this.errorHandler = null;
 
         /**
-         * Timeout for resubmitting results.
-         *
-         * @property watchdogTimeout
-         * @private
-         * @type Object|null
-         */
-        this.watchdogTimeout = null;
-
-        /**
          * Timeout for page navigation.
          *
          * @property navigateTimeout
@@ -295,7 +286,6 @@ YUI.add("tempest", function (Y, name) {
         this.scanning = false;
 
         this.lastPong = new Date();
-        this.lastWatchdogCheck = new Date();
 
         this.setupWindowHandlers();
 
@@ -425,17 +415,6 @@ YUI.add("tempest", function (Y, name) {
     };
 
     /**
-     * Cancel watchdog timer.
-     *
-     * @method cancelWatchdog
-     */
-    proto.cancelWatchdog = function () {
-        if (this.watchdogTimeout) {
-            this.watchdogTimeout.cancel();
-        }
-    };
-
-    /**
      * Destroy this instance.
      *
      * @method destroy
@@ -506,8 +485,6 @@ YUI.add("tempest", function (Y, name) {
         self.tower.on("navigate", function onNavigate(test) {
             var timeout = self.get("navigateTimeoutMilliseconds");
 
-            self.cancelWatchdog();
-
             if (self.navigateTimeout) {
                 // Yeti server wants us on another page
                 // because our navigateTimeout is so long.
@@ -540,27 +517,12 @@ YUI.add("tempest", function (Y, name) {
                     ";path=/;expires=Sat, 10 Mar 2029 08:00:00 GMT";
             }
             self.deliverResultsIfNeeded();
-/*
-            (function watchdog() {
-                self.debug("Begin check...");
-                self.debug("Watchdog check...", self.lastPong.getTime(), self.lastWatchdogCheck.getTime(), self.lastPong.getTime() - self.lastWatchdogCheck.getTime());
-                var delta = self.lastPong.getTime() - self.lastWatchdogCheck.getTime();
-                if (delta > 10000 || delta < 0) {
-                    self.debug("Watchdog failure!");
-                    Y.config.win.location.href = Y.config.win.location.href;
-                }
-                self.lastWatchdogCheck = new Date();
-                self.watchdogTimeout = Y.later(5000, null, watchdog);
-            }());
-*/
         });
 
         self.tower.on("close", function onClose() {
             if (self.destroySoon) {
                 return;
             }
-
-            self.cancelWatchdog();
             self.debug("Closed, reconnecting in 5 sec.");
             self.setStatus("Closed, reconnecting in 5 seconds.");
             self.tower.queueUntil("open"); // collect events for reconnecting

--- a/test/functional/functional.js
+++ b/test/functional/functional.js
@@ -612,7 +612,6 @@ vows.describe("Yeti Functional")
         "visits Yeti with invalid files": errorContext(withTests("this-file-does-not-exist.html"))
     }))
     .addBatch(attachServerBatch({
-        "A HTTP server with an upgrade listener (for Yeti files)": withTests("basic.html", "local-js.html"),
         "A HTTP server with an upgrade listener (for Yeti paths)": {
             tests: ["/fixture"],
             useProxy: false


### PR DESCRIPTION
TL;DR:
- Replace timeout feature with a test-specific timeout and a browser-response timeout.
- Browser has to keep responding or else it gets killed within 3-5 seconds.
- Each test must complete within the test-specific timeout.
- Introduce some robustness enhancements to the client-side script.
- If a browser crash happens during a test run, attempt to run that test again.

Recent refactoring broke the timeout feature. Additionally, the old implementation of test timeouts was based on a very fragile setTimeout in `AllAgents` that had to be rescheduled every time a new batch was created with a different timeout value. Timeouts were supposed to abort very slow tests, but they were also occurring in previous 0.2.x releases if a browser crashed without letting Yeti know.

This pull request addresses both problems.

Separate internal timeouts are needed for determining if a test is taking too long vs. if a browser has stopped responding. These two timeouts are needed per browser. Instead of creating a lot of setTimeouts, we introduce a `PeriodicRegistry` to run all of our health checks with one setTimeout. This replaces the complex logic inside of `AllAgents`.

We also introduce a browser ping. The ping is sent if no response (e.g., results or beat events) come from the browser for a few seconds. After 3 pings without a response, we consider it dead. This should allow users of the Yeti API to take action quickly if a browser is stalled (e.g. by restarting it). This applies to tests and the capture page.

This also updates the UI for old browsers that cannot use streaming protocols to communicate with Yeti: instead of getting updates in the UI after every test, we now see movement of the spinner every 3-5 seconds or so.

Having two internal timeouts lets us increate the default test timeout value to 5 minutes from 45 seconds, since dead browsers would be caught by the unresponsive pings.

We also introduce some logic in the client-side `tempest.js` to:
- Resend test results if the first send failed.
- Wait longer for IE 6, 7, and Android browsers before navigating to the next test.
- Respond to server ping requests.

Finally, we also no longer use a separate pending test queue in `Tests`. We instead check for tests without results that are not already being currently ran. This significant change lets us give a test that one browser failed to run to another identical browser after we consider the first instance dead.

These changes help make using old browsers more reliable and catch crashed browsers much faster and accurately.
