### PR TITLE
Report all fires of window.onerror.

### DIFF
--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -164,7 +164,6 @@ Agent.prototype.setupEvents = function () {
 
     self.socketEmitter.on("scriptError", function (details) {
         self.emit("scriptError", details);
-        self.next();
     });
 
     self.socketEmitter.on("heartbeat", function () {

--- a/lib/hub/agent.js
+++ b/lib/hub/agent.js
@@ -162,8 +162,9 @@ Agent.prototype.setupEvents = function () {
         self.next();
     });
 
-    self.socketEmitter.on("scriptError", function (details) {
-        self.emit("scriptError", details);
+    self.socketEmitter.on("scriptError", function (data) {
+        data.url = self.currentUrl;
+        self.emit("scriptError", data);
     });
 
     self.socketEmitter.on("heartbeat", function () {

--- a/lib/hub/target.js
+++ b/lib/hub/target.js
@@ -114,8 +114,7 @@ Target.prototype.setupEvents = function () {
         // TODO: Set results should include error message.
         test.setResults({});
         test.setExecuting(false);
-        // TODO Why is test.location sometimes undefined?
-        if (test.location) { data.url = test.location; }
+        data.url = test.location;
         self.emit("scriptError", data);
     });
     self.agentEmitter.on("beat", self.emit.bind(self, "beat"));

--- a/lib/hub/target.js
+++ b/lib/hub/target.js
@@ -114,7 +114,8 @@ Target.prototype.setupEvents = function () {
         // TODO: Set results should include error message.
         test.setResults({});
         test.setExecuting(false);
-        data.url = test.location;
+        // TODO Why is test.location sometimes undefined?
+        if (test.location) { data.url = test.location; }
         self.emit("scriptError", data);
     });
     self.agentEmitter.on("beat", self.emit.bind(self, "beat"));

--- a/lib/hub/target.js
+++ b/lib/hub/target.js
@@ -109,7 +109,14 @@ Target.prototype.setupEvents = function () {
         test.setExecuting(false);
         self.emit("results", data);
     });
-    self.agentEmitter.on("scriptError", self.emit.bind(self, "scriptError"));
+    self.agentEmitter.on("scriptError", function (data) {
+        var test = self.tests.getByUrl(data.url);
+        // TODO: Set results should include error message.
+        test.setResults({});
+        test.setExecuting(false);
+        data.url = test.location;
+        self.emit("scriptError", data);
+    });
     self.agentEmitter.on("beat", self.emit.bind(self, "beat"));
     self.agentEmitter.on("agentError", self.emit.bind(self, "agentError"));
     // TODO handle disconnects

--- a/lib/hub/view/public/inject.js
+++ b/lib/hub/view/public/inject.js
@@ -11,12 +11,22 @@ window.$yetify = function (options) {
     // Request focus.
     window.focus();
 
+    // Setup basic error handler during startup.
+    var errors = [];
+    window.onerror = function beforeDomReadyErrorHandler(message, url, line) {
+        errors.push([message, url, line]);
+    };
+
     YUI({
         delayUntil: "domready"
     }).use("tempest", function bootInjectedDriver(Y) {
         var driver = new Y.InjectedDriver({
             resource: options.mountpoint
         });
+
+        driver.once("ready",
+            Y.bind(driver.transferErrorHandler, driver, errors)
+        );
 
         // Request focus, again.
         Y.later(0, Y.config.win, Y.config.win.focus);

--- a/lib/hub/view/public/tempest.js
+++ b/lib/hub/view/public/tempest.js
@@ -250,15 +250,6 @@ YUI.add("tempest", function (Y, name) {
         this.unloadHandler = null;
 
         /**
-         * Page error event handler.
-         *
-         * @property errorHandler
-         * @private
-         * @type EventHandle|null
-         */
-        this.errorHandler = null;
-
-        /**
          * Timeout for page navigation.
          *
          * @property navigateTimeout
@@ -288,6 +279,7 @@ YUI.add("tempest", function (Y, name) {
         this.lastPong = new Date();
 
         this.setupWindowHandlers();
+        this.didSetupWindowHandlers = false;
 
         this.automation = new Y.AutomationGroup();
     }
@@ -367,6 +359,7 @@ YUI.add("tempest", function (Y, name) {
 
     Y.extend(InjectedDriver, Y.TempestBaseCore);
     Y.augment(InjectedDriver, Y.AttributeEvents);
+    Y.augment(InjectedDriver, Y.EventTarget);
 
     proto = InjectedDriver.prototype;
 
@@ -422,7 +415,6 @@ YUI.add("tempest", function (Y, name) {
     proto.destroy = function () {
         var self = this;
         self.unloadHandler.detach();
-        self.errorHandler.detach();
         self.hub.destroy();
         InjectedDriver.superclass.destroy.call(self);
         self = null;
@@ -511,6 +503,7 @@ YUI.add("tempest", function (Y, name) {
 
         self.tower.on("ready", function onReady() {
             self.setStatus("Waiting for tests...");
+            self.fire("ready");
             if (self.get("captureOnly")) {
                 // attachServer() tests use cookies instead of the URL
                 document.cookie = "yeti-agent=" + self.get("agentId") +
@@ -550,34 +543,48 @@ YUI.add("tempest", function (Y, name) {
         self.automation.on("beat", Y.bind(self.beat, self));
     };
 
+    proto.errorHandler = function errorHandler(message, url, line) {
+        this.debug("errorHandler", message, url, line);
+
+        // Firefox throws on script includes that 404.
+        if (
+            message &&
+            "string" === typeof message &&
+            message.toLowerCase().indexOf("error loading") !== -1
+        ) {
+            // Ignore.
+            return true;
+        }
+
+        if (this.tower) {
+            this.tower.emit("scriptError", {
+                message: message,
+                url: url,
+                line: line
+            });
+        }
+
+        return true;
+    };
+
+    proto.transferErrorHandler = function (errors) {
+        var self = this;
+        function expandAndReport(error) {
+            self.errorHandler.apply(self, error);
+        }
+        Y.Array.each(errors, expandAndReport, self);
+        Y.config.win.onerror = Y.bind(self.errorHandler, self);
+    };
+
+    // TODO: This needs to go away and be handled in inject.js.
     proto.setupWindowHandlers = function () {
         var self = this;
 
-        self.debug("Attaching window event handlers.");
-
-        function errorHandler(message, url, line) {
-            self.debug("errorHandler", message, url, line);
-
-            // Firefox throws on script includes that 404.
-            if (
-                message &&
-                "string" === typeof message &&
-                message.toLowerCase().indexOf("error loading") !== -1
-            ) {
-                // Ignore.
-                return true;
-            }
-
-            if (self.tower) {
-                self.tower.emit("scriptError", {
-                    message: message,
-                    url: url,
-                    line: line
-                });
-            }
-
-            return true;
+        if (self.didSetupWindowHandlers) {
+            return false;
         }
+
+        self.debug("Attaching window event handlers.");
 
         function unloadHandler() {
             var img = new Image();
@@ -587,8 +594,8 @@ YUI.add("tempest", function (Y, name) {
         }
 
         // Requires node-base.
-        self.errorHandler = Y.on("error", errorHandler, win);
         self.unloadHandler = Y.on("unload", unloadHandler, win);
+        self.didSetupWindowHandlers = true;
     };
 
     Y.InjectedDriver = InjectedDriver;


### PR DESCRIPTION
Additionally, mark the test as having results so that it
won't be ran again. The reported URL is simplified if possible.
## TODO
- [x] Continue to run tests even if agentError occurs.
- [x] Investigate why `test.location` does not always work.
