### PR TITLE
Allow client to set `wd-url` setting.

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -442,6 +442,7 @@ CLI.prototype.runBatch = function runBatch(options) {
     this.resolveFilesToBasedir(options);
 
     var self = this,
+        webdriver = self.getWebDriverConfigurationFromOptions(options),
         files = options.get("files"),
         browsers = options.get("browser"),
         port = options.get("port"),
@@ -480,6 +481,7 @@ CLI.prototype.runBatch = function runBatch(options) {
             } else if (browsers) {
                 self.error("Waiting for Hub to launch browsers...");
                 batchOptions.launchBrowsers = browsers;
+                batchOptions.webdriver = webdriver;
                 self.submitBatch(client, options.get("output"), batchOptions);
             } else {
                 self.error("Waiting for agents to connect at " + externalUrl);

--- a/lib/hub/all-batches.js
+++ b/lib/hub/all-batches.js
@@ -49,7 +49,7 @@ AllBatches.prototype.createBatch = function (session, spec, reply) {
     batch.batchSession.once("end", this.destroyBatch.bind(this, options.id));
 
     if (options.spec.launchBrowsers) {
-        batch.launchAndDispatch(options.spec.launchBrowsers, reply);
+        batch.launchAndDispatch(reply);
     } else {
         reply(null, options.id);
         batch.dispatch();

--- a/lib/hub/batch.js
+++ b/lib/hub/batch.js
@@ -196,7 +196,7 @@ Batch.prototype.getId = function () {
     return this.id;
 };
 
-Batch.prototype.launchAndDispatch = function (browsers, reply) {
+Batch.prototype.launchAndDispatch = function (reply) {
     var self = this,
         address,
         remote,
@@ -204,7 +204,8 @@ Batch.prototype.launchAndDispatch = function (browsers, reply) {
 
     self.managedBrowsers = new WebDriverCollection({
         hub: self.allBatches.hub,
-        browsers: browsers
+        browsers: self.spec.launchBrowsers,
+        webdriver: self.spec.webdriver
     });
 
     self.managedBrowsers.launch(function (err) {

--- a/lib/hub/test-specification.js
+++ b/lib/hub/test-specification.js
@@ -18,6 +18,12 @@ var Tests = require("./tests");
  * @param {Boolean} [spec.useProxy] True if tests are filenames to proxy to the Hub.
  *                           false if they are literal URL pathnames.
  *                           If not provided, defaults to true.
+ * @param {Object[]} [spec.launchBrowsers] Array of WebDriver capabilities to launch.
+ * @param {Object} [spec.webdriver] Requested WebDriver hub.
+ * @param {String} [spec.webdriver.host] WebDriver host.
+ * @param {Number} [spec.webdriver.port] WebDriver port.
+ * @param {String} [spec.webdriver.user] WebDriver username.
+ * @param {String} [spec.webdriver.pass] WebDriver password.
  */
 function TestSpecification(spec) {
     this.batchId = spec.batchId;
@@ -26,6 +32,8 @@ function TestSpecification(spec) {
     this.basedir = spec.basedir;
     this.timeout = spec.timeout || TestSpecification.DEFAULT_TIMEOUT;
     this.useProxy = spec.useProxy;
+    this.launchBrowsers = spec.launchBrowsers;
+    this.webdriver = spec.webdriver;
 
     this.mountpount = this.setMountpoint(spec.mountpoint);
 }

--- a/lib/hub/webdriver-collection.js
+++ b/lib/hub/webdriver-collection.js
@@ -10,7 +10,12 @@ function WebDriverCollection(options) {
     this.desiredCapabilities = options.browsers;
     this.hub = options.hub;
 
-    this.remote = options.hub.webdriver;
+    if (options.webdriver) {
+        this.remote = options.webdriver;
+    } else {
+        this.remote = options.hub.webdriver;
+    }
+
     this.allAgents = options.hub.allAgents;
     this.browsers = [];
     this.agentIds = [];


### PR DESCRIPTION
In addition to specifiying the browsers to launch, allow the
client to pass along the WebDriver hub to use for launching.
