### PR TITLE
Dependency free postinstall for Yogi

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "sockjs": "~0.3.1",
     "proto-list": "~1.2.2",
     "glob": "~3.2.1",
-    "graceful-fs": "~1.2.0"
+    "graceful-fs": "~1.2.0",
+    "request": "~2.21.0"
   },
   "devDependencies": {
     "mocks": "https://github.com/vojtajina/node-mocks/tarball/master",

--- a/scripts/fetch_deps.js
+++ b/scripts/fetch_deps.js
@@ -5,8 +5,7 @@
 var fs = require("fs"),
     url = require("url"),
     path = require("path"),
-    http = require("http"),
-    https = require("https");
+    request = require("request");
 
 var depDir = path.join(__dirname, "..", "dep");
 
@@ -89,9 +88,12 @@ function die(message) {
 }
 
 function saveURLToDep(sourceURL, filename, cb) {
-    var protocol = url.parse(sourceURL).protocol;
+    var protocol = url.parse(sourceURL).protocol,
+        env = process.env,
+        proxy;
 
-    protocol = (protocol === "http:") ? http : https;
+    protocol = protocol.replace(':', '');
+    proxy = env[protocol + '_proxy'] || env[protocol.toUpperCase() + '_PROXY'] || '';
     filename = path.join(depDir, filename);
 
     function done() {
@@ -100,24 +102,17 @@ function saveURLToDep(sourceURL, filename, cb) {
 
     log("Saving", sourceURL, "as", filename);
 
-    protocol.get(url.parse(sourceURL), function onResponse(res) {
+    request({
+        proxy: proxy,
+        url: sourceURL
+    }, function(error, res, body) {
         if (res.statusCode !== 200) {
             die("Got status " + res.statusCode + " for URL " + sourceURL);
             return;
         }
 
-        var data = "";
-
-        res.setEncoding("utf8");
-
-        res.on("data", function (chunk) {
-            data += chunk;
-        });
-
-        res.on("end", function () {
-            fs.writeFile(filename, data, "utf8", done);
-        });
-    }).on("error", die);
+        fs.writeFile(filename, body, "utf8", done);
+    });
 }
 
 function download(err) {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -4,6 +4,7 @@
 
 var fs = require("fs"),
     path = require("path"),
+    existsSync = fs.existsSync || path.existsSync,
     history;
 
 function log() {
@@ -12,7 +13,10 @@ function log() {
     }
 }
 
-require("./fetch_deps");
+// Avoid fetching deps if possible. See GH-42.
+if (!fs.existsSync(path.join(__dirname, "..", "dep"))) {
+    require("./fetch_deps");
+}
 
 fs.readFile(path.join(__dirname, "..", "HISTORY.md"), "utf8", function (err, data) {
     history = data.split("\n").slice(2, 20).join("\n");
@@ -21,6 +25,3 @@ fs.readFile(path.join(__dirname, "..", "HISTORY.md"), "utf8", function (err, dat
         log("\nRecent changes in HISTORY.md:\n\n" + history);
     });
 });
-
-
-


### PR DESCRIPTION
Steps to resolution:
- [ ] This should be merged into master immediately before a Yeti release. Merging too early will break Yogi since it uses latest.yeti.cx.
- [ ] Yogi needs a release to depend on that new Yeti release right away.
- [ ] YUI needs to depend on that new Yogi release.

<!---
@huboard:{"order":43.0}
-->
