### PR TITLE
Wait until QUnit is loaded, before checking for it in inject.js.

### DIFF
--- a/lib/hub/view/public/inject.js
+++ b/lib/hub/view/public/inject.js
@@ -4,9 +4,11 @@ window.$yetify = function (options) {
 
     // Do not start QUnit tests before bind,
     // we need to setup logging callbacks first.
-    if (window.QUnit && window.QUnit.config) {
-        window.QUnit.config.autostart = false;
-    }
+    window.onload = function () {
+        if (window.QUnit && window.QUnit.config) {
+            window.QUnit.config.autostart = false;
+        }
+    };
 
     // Request focus.
     window.focus();


### PR DESCRIPTION
First, I do not expect this to be pulled in, since it is a wrong way to do this anyway. Initial idea was to run this code only if QUnit framework is detected below, but for some reason:

``` javascript
YUI({
        delayUntil: "domready"
    }).use("tempest", function bootInjectedDriver(Y) {
    ...
```

runs _after_ `window.onload` (huh) and then it is obviously too late to stop QUnit from auto-starting.

Quick and dirty way to fix: #44.

This works because autostart is requested by QUnit on window.load as well.
