### PR TITLE
Omit port from SockJS URL if not available. GH-46.

### DIFF
--- a/lib/cli/reporter/feedback-line.js
+++ b/lib/cli/reporter/feedback-line.js
@@ -175,7 +175,7 @@ FeedbackLineReporter.prototype.formatTime = function (milliseconds) {
         seconds %= 60;
     }
 
-    minutesUnit = minutes === 1 ? "minute" : "minutes",
+    minutesUnit = minutes === 1 ? "minute" : "minutes";
     secondsUnit = seconds === 1 ? "second" : "seconds";
 
     if (minutes > 0) {

--- a/lib/hub/view/public/tempest.js
+++ b/lib/hub/view/public/tempest.js
@@ -95,12 +95,19 @@ YUI.add("tempest-hubclient", function (Y, name) {
     ATTRS.sockUrl = {
         readOnly: true,
         valueFn: function () {
-            var doc = Y.config.doc;
+            var doc = Y.config.doc,
+                portPart = "";
+
+            // Port property may be empty on IE.
+            if (doc.location.port) {
+                portPart = ":" + doc.location.port;
+            }
+
             return [
                 doc.location.protocol,
                 "//",
                 doc.domain,
-                ":" + doc.location.port,
+                portPart,
                 this.get("resource"),
                 "/tower"
             ].join("");


### PR DESCRIPTION
The document.location.port may be the empty string on IE
when a default port is being used. In that case, avoid
putting a port, or colon, in the URL to prevent a SyntaxError
during WebSocket construction.
