### PR TITLE
Add a --coverage-dump option to save coverage results to files

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ Yeti automatically includes a line coverage summary if your tests were instrumen
     ✔ Testing started on Safari (6.0) / Mac OS
     ► Testing... \ 13% complete (10/60) 11.85 tests/sec ETA 4 minutes, 2 seconds 44% line coverage
 
+
+The coverage results can be dumped using the `--coverage-dump` option :
+
+    $ mkdir coverage-results
+    $ yeti myproject/src/*/tests/unit/*.html --coverage-dump coverage-results --query 'filter=coverage'
+
+If your code is instrumented using istanbul, you can then generate the HTML coverage reports :
+
+    $ istanbul report --root coverage-results
+
 #### AJAX testing
 
 Yeti provides server-side AJAX routes with [echoecho][ee]. Your test can

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -9,6 +9,7 @@ var Configuration = require("./configuration");
 var path = require("path");
 var glob = require("glob");
 var urlUtil = require("url");
+var fs = require("fs");
 var readline = require("readline");
 var util = require("util");
 var url = require("url");
@@ -47,7 +48,8 @@ var parseArgv = exports.parseArgv = function (argv) {
         "port": Number,
         "timeout": Number,
         "hub": url,
-        "help" : Boolean
+        "help" : Boolean,
+        "coverage-dump" : String
     }, shortHands = {
         "b": ["--browser"],
         "junit": ["--output", "junit"],
@@ -243,7 +245,7 @@ CLI.prototype.setupExceptionHandler = function () {
  * @param {Function} cb Completion callback.
  */
 CLI.prototype.submitBatch = function submitBatch(client, output, options, cb) {
-    var reporter, batch, reporterOptions;
+    var reporter, batch, reporterOptions, covStats, agentResultIndex;
 
     batch = client.createBatch(options);
 
@@ -251,6 +253,24 @@ CLI.prototype.submitBatch = function submitBatch(client, output, options, cb) {
         cli: this,
         batch: batch
     };
+
+
+    if (!!options["coverage-dump"]) {
+        try {
+            covStats = fs.lstatSync(options["coverage-dump"]);
+            if (covStats.isDirectory()) {
+                agentResultIndex = 0;
+                batch.on("agentResult", function (agent, details) {
+                    if (details.coverage) {
+                        fs.writeFileSync(path.join(options["coverage-dump"], "coverage-" + agentResultIndex + ".json"), JSON.stringify(details.coverage, null, 3));
+                        agentResultIndex += 1;
+                    }
+                });
+            }
+        }
+        catch (e) {}
+    }
+    
 
     if (output === "junit") {
         reporter = new JUnitReporter(reporterOptions);
@@ -464,7 +484,8 @@ CLI.prototype.runBatch = function runBatch(options) {
             basedir: options.get("basedir"),
             query: query,
             timeout: options.get("timeout"),
-            tests: files
+            tests: files,
+            "coverage-dump": options.get("coverage-dump")
         };
 
     browsers = self.parseBrowsers(browsers);
@@ -593,6 +614,7 @@ CLI.prototype.route = function (argv) {
                 " [--hub=<url>] [--loglevel <level>] [--timeout <seconds>]" +
                 " [--query <params>] [--basedir <directory>] [--browser <name[/version]>...]" +
                 " [--wd-url <url>] [--self-url <url>]" +
+                " [--coverage-dump <directory>] " +
                 " [--help] [--] [<HTML file>...]";
 
     config.pipeLog(this);

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -245,7 +245,8 @@ CLI.prototype.setupExceptionHandler = function () {
  * @param {Function} cb Completion callback.
  */
 CLI.prototype.submitBatch = function submitBatch(client, output, options, cb) {
-    var reporter, batch, reporterOptions, covStats, agentResultIndex;
+    var reporter, batch, reporterOptions, covStats, agentResultIndex,
+        covFilename, covData, self = this;
 
     batch = client.createBatch(options);
 
@@ -256,19 +257,23 @@ CLI.prototype.submitBatch = function submitBatch(client, output, options, cb) {
 
 
     if (!!options["coverage-dump"]) {
-        try {
-            covStats = fs.lstatSync(options["coverage-dump"]);
-            if (covStats.isDirectory()) {
-                agentResultIndex = 0;
-                batch.on("agentResult", function (agent, details) {
-                    if (details.coverage) {
-                        fs.writeFileSync(path.join(options["coverage-dump"], "coverage-" + agentResultIndex + ".json"), JSON.stringify(details.coverage, null, 3));
-                        agentResultIndex += 1;
+        covStats = fs.lstatSync(options["coverage-dump"]);
+        if (covStats.isDirectory()) {
+            agentResultIndex = 0;
+            batch.on("agentResult", function (agent, details) {
+                if (details.coverage) {
+                    covFilename = path.join(options["coverage-dump"], "coverage-" + agentResultIndex + ".json");
+                    try {
+                        covData = JSON.stringify(details.coverage, null, 3);
+                    } catch (e) {
+                        covData = "";
+                        self.error("Unable to dump coverage due to " + e.message + ".");
                     }
-                });
-            }
+                    fs.writeFileSync(covFilename, covData);
+                    agentResultIndex += 1;
+                }
+            });
         }
-        catch (e) {}
     }
     
 


### PR DESCRIPTION
We use this option to store the coverage results into JSON files, so that we can generate HTML reports later.
