### PR TITLE
Added generic driver

### DIFF
--- a/lib/hub/view/public/inject.js
+++ b/lib/hub/view/public/inject.js
@@ -411,6 +411,19 @@ window.$yetify = function (options) {
             }
         });
 
+        driver.addAutomation("test", "generic", {
+            detectFn: function (win) {
+                return Y.config.win.genericYetiDriver;
+            },
+            bindFn: function (win) {
+                var self = this;
+
+                Y.config.win.yetiComplete = function (results) {
+                    self.fire("results", results);
+                };
+            }
+        });
+
         driver.addAutomation("coverage", "yui", {
             detectFn: function (win) {
                 return win.YUITest && win.YUITest.TestRunner &&

--- a/lib/hub/view/public/inject.js
+++ b/lib/hub/view/public/inject.js
@@ -413,12 +413,12 @@ window.$yetify = function (options) {
 
         driver.addAutomation("test", "generic", {
             detectFn: function (win) {
-                return Y.config.win.genericYetiDriver;
+                return Y.config.win.stopYetiScan;
             },
             bindFn: function (win) {
                 var self = this;
 
-                Y.config.win.yetiComplete = function (results) {
+                Y.config.win.sendYetiResults = function (results) {
                     self.fire("results", results);
                 };
             }


### PR DESCRIPTION
Yeti should have a basic, generic driver for any apps that wish to submit test results, but not hack into Yeti's `inject.js`.  Here's a patch that adds just that.  If you have any ideas for something other than a global function to submit results, lemme know.  I figured it would be ideal to not be library-dependent for something generic.

Ideally, I think there should be a global `Yeti` object with a `submitResults` or `results` event listener, so

```
Yeti.submitResults(results);
```

or

```
Yeti.emit('results', results);
```

But this works until more thought can be put into it.
