### PR TITLE
Fix the user agent parser for Opera 15 and IE 11

### DIFF
--- a/lib/hub/ua.js
+++ b/lib/hub/ua.js
@@ -113,7 +113,7 @@ module.exports = function (ua) {
             version = m[1];
         }
     } else {
-        m = ua.match(/MSIE ([^;]*)|Trident.*; rv ([0-9.]+)/);
+        m = ua.match(/MSIE ([^;]*)|Trident.*; rv:([0-9.]+)/);
         if (m && (m[1] || m[2])) {
             version = m[1] || m[2];
             name = 'Internet Explorer';

--- a/lib/hub/ua.js
+++ b/lib/hub/ua.js
@@ -92,11 +92,16 @@ module.exports = function (ua) {
                 name = 'Safari';
             }
         }
-
-        m = ua.match(/(Chrome|CrMo|CriOS)\/([^\s]*)/);
-        if (m && m[1] && m[2]) {
-            version  = m[2]; // Chrome
-            name = 'Chrome';
+        m = ua.match(/OPR\/(\d+\.\d+)/);
+        if (m && m[1]) {
+            version = m[1];
+            name = 'Opera';
+        } else {
+            m = ua.match(/(Chrome|CrMo|CriOS)\/([^\s]*)/);
+            if (m && m[1] && m[2]) {
+                version = m[2];
+                name = 'Chrome';
+            }
         }
     }
     m = ua.match(/Opera[\s\/]([^\s]*)/);
@@ -108,9 +113,9 @@ module.exports = function (ua) {
             version = m[1];
         }
     } else {
-        m = ua.match(/MSIE\s([^;]*)/);
-        if (m && m[1]) {
-            version = m[1];
+        m = ua.match(/MSIE ([^;]*)|Trident.*; rv ([0-9.]+)/);
+        if (m && (m[1] || m[2])) {
+            version = m[1] || m[2];
             name = 'Internet Explorer';
         } else { // not opera, webkit, or ie
             m = ua.match(/Gecko\//);


### PR DESCRIPTION
For both Opera 15 and IE 11, it can't detects the right user agent by the traditional means. Basically this change is same approach with the parser of YUI core.
