### PR TITLE
Add ignore configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,8 @@ Here is an example `.yeti.json` for the YUI project, which is placed in the repo
     {
         "hub": "http://test.yeti.cx/",
         "basedir": ".",
-        "glob": "**/tests/unit/*.html"
+        "glob": "**/tests/unit/*.html",
+        "ignore": "node_modules/**/*.html"
     }
 
 Here is the breakdown of these settings:
@@ -268,6 +269,7 @@ Here is the breakdown of these settings:
  - The *basedir* option indicates that the directory where `.yeti.json` lives is
     permitted to serve files to the Yeti Hub.
  - The *glob* option defines a pattern to search for test files.
+ - The *ignore* option defines a pattern to search for test files to ignore.
 
 These settings let YUI developers simply run `yeti` inside of the project directory
 to run tests. Since all tests in the project match the glob pattern, the `yeti`

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -288,19 +288,33 @@ CLI.prototype.submitBatch = function submitBatch(client, options, clientOptions,
 CLI.prototype.prepareBatch = function prepareBatch(config, cb) {
     var self = this,
         pattern = config.get("glob"),
+        ignore = config.get("ignore"),
         unit = "files";
+
+    function setFiles(matches) {
+        config.set("files", matches);
+        if (matches.length === 1) {
+            unit = "file";
+        }
+        self.error("Found", matches.length, unit, "to test.");
+        cb(config);
+    }
 
     if (pattern && !config.get("files")) {
         glob(pattern, function (err, matches) {
             if (matches) {
-                config.set("files", matches);
-
-                if (matches.length === 1) {
-                    unit = "file";
+                if (ignore) {
+                    glob(ignore, function (err, ignoreMatches) {
+                        if (ignoreMatches) {
+                            matches = matches.filter(function (value) {
+                                return ignoreMatches.indexOf(value) === -1;
+                            });
+                        }
+                        setFiles(matches);
+                    });
+                } else {
+                    setFiles(matches);
                 }
-                self.error("Found", matches.length, unit, "to test.");
-
-                cb(config);
             } else {
                 self.panic("Glob pattern", pattern, "matched zero files.");
             }


### PR DESCRIPTION
This option is intended to exclude globbed directories. Fix #57. See also yui/yui3#778.
