### PR TITLE
fixes #68. doh support was broken for some testsuites

### DIFF
--- a/lib/hub/view/public/inject.js
+++ b/lib/hub/view/public/inject.js
@@ -390,7 +390,7 @@ window.$yetify = function (options) {
                 };
 
                 doh._groupStarted = function (group) {
-                    results[group] = {};
+                    results[group] = results[group] || {};
                 };
 
                 doh._groupFinished = function (group, success) {


### PR DESCRIPTION
DOH support was broken for test suites with multiple test cases

`doh._groupStarted` is called between each test case and the previous test case result was being overwritten.
