### PR TITLE
fixes #67. the older version of the admc/wd module was not working.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "async": "~0.2.5",
-    "wd": "~0.0.27",
+    "wd": "~0.2.5",
     "echoecho": "~0.1.6",
     "eventemitter2": "~0.4.8",
     "eventyoshi": "~0.1.2",


### PR DESCRIPTION
We have our own selenium2 grid setup with version 2.37.0. When pointing the yeti server at our grid there were errors "The environment you requested was unavailable"

I did some debugging and found that the version of the admc/wd@~0.0.27 module that yeti is using is out of date. It was scraping the selenium sessionId from the response "location" header but that header was null in my case. The new updates of admc/wd@0.2.5 properly get the sessionId from the JSON object in the response body
