### PR TITLE
Allow deferred initialization of mocha test runner via a flag

### DIFF
--- a/lib/hub/view/public/inject.js
+++ b/lib/hub/view/public/inject.js
@@ -255,70 +255,88 @@ window.$yetify = function (options) {
                 var self = this,
                     tostring = {}.toString,
                     mocha = win.mocha,
-                    runner = mocha.run(),
+                    runner = mocha.run,
                     data = {},
                     tests = {},
                     passed = 0,
                     failed = 0,
                     total = 0;
 
-                function complete(results) {
-                    self.fire("results", results);
-                }
+                //override the existing mocha.run
+                //so we can initialize it async if we need to
+                mocha.run = function () {
 
-                runner.ignoreLeaks = true;
+                    //restore the override
+                    mocha.run = runner;
+                    //initialize mocha and get a reference to the runner
+                    runner = runner();
 
-                runner.on('test end', function (test) {
-                    var suiteName = test.title;
+                    function complete(results) {
+                        self.fire("results", results);
+                    }
 
-                    tests[suiteName] = {
-                        message: (test.state === 'failed') ? test.err.message : "",
-                        result: (test.state === 'passed') ? true : "fail",
-                        name: suiteName
-                    };
+                    runner.ignoreLeaks = true;
 
-                    passed = (test.state === 'passed') ? passed + 1 : passed;
-                    failed = (test.state === 'failed') ? failed + 1 : failed;
-                    total = total + 1;
-                });
+                    runner.on('test end', function (test) {
+                        var suiteName = test.title;
 
-
-                runner.on('suite end', function (module) {
-                    if (module.suites.length === 0) {
-                        var suiteName = module.fullTitle(),
-                            i;
-
-                        data[suiteName] = {
-                            name: suiteName,
-                            passed: passed,
-                            failed: failed,
-                            total: total
+                        tests[suiteName] = {
+                            message: (test.state === 'failed') ? test.err.message : "",
+                            result: (test.state === 'passed') ? true : "fail",
+                            name: suiteName
                         };
 
-                        for (i in tests) {
-                            data[suiteName][tests[i].name] = {
-                                result: tests[i].result,
-                                message: tests[i].message,
-                                name: tests[i].name
+                        passed = (test.state === 'passed') ? passed + 1 : passed;
+                        failed = (test.state === 'failed') ? failed + 1 : failed;
+                        total = total + 1;
+                    });
+
+
+                    runner.on('suite end', function (module) {
+                        if (module.suites.length === 0) {
+                            var suiteName = module.fullTitle(),
+                                i;
+
+                            data[suiteName] = {
+                                name: suiteName,
+                                passed: passed,
+                                failed: failed,
+                                total: total
                             };
+
+                            for (i in tests) {
+                                data[suiteName][tests[i].name] = {
+                                    result: tests[i].result,
+                                    message: tests[i].message,
+                                    name: tests[i].name
+                                };
+                            }
+
+                            tests = {};
+                            passed = failed = total = 0;
                         }
+                    });
+                    runner.on('end', function (test) {
+                        var results = data;
 
-                        tests = {};
-                        passed = failed = total = 0;
-                    }
-                });
-                runner.on('end', function (test) {
-                    var results = data;
+                        results.passed = (runner.total - runner.failures) || 0;
+                        results.failed = runner.failures || 0;
+                        results.total = runner.total;
+                        // TODO: How do I get the test suite runtime?
+                        results.duration = 0;
+                        results.name = document.title;
 
-                    results.passed = (runner.total - runner.failures) || 0;
-                    results.failed = runner.failures || 0;
-                    results.total = runner.total;
-                    // TODO: How do I get the test suite runtime?
-                    results.duration = 0;
-                    results.name = document.title;
+                        complete(results);
+                    });
+                };
 
-                    complete(results);
-                });
+                //don't run if we've explicitly flagged this
+                //mocha instance as being async initialized
+                //otherwise call `run` to set up the test bindings and
+                //start the test runner
+                if (!mocha.asyncYeti) {
+                    mocha.run();
+                }
             }
         });
 

--- a/test/functional/cli.js
+++ b/test/functional/cli.js
@@ -146,6 +146,7 @@ vows.describe("Yeti CLI").addBatch({
                     __dirname + "/fixture/qunit.html",
                     __dirname + "/fixture/jasmine.html",
                     __dirname + "/fixture/mocha.html",
+                    __dirname + "/fixture/mocha-async.html",
                     __dirname + "/fixture/doh.html"
                 ]);
             });

--- a/test/functional/fixture/mocha-async.html
+++ b/test/functional/fixture/mocha-async.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="../../../dep/dev/mocha.css" />
     <script src="../../../dep/dev/mocha.js"></script>
     <script src="../../../dep/dev/expect.js"></script>
+    <script type="text/javascript" src="../../../dep/dev/yui-test.js"></script>
   </head>
   <body>
     <div id="mocha"></div>
@@ -14,18 +15,18 @@
     mocha.asyncYeti = true;
 
     //simulate an async initialization of mocha
-    //using a timeout.
-    setTimeout(function(){
-  		describe('hi mocha', function(){
-  			it('should have a passing test', function(){
-  			  expect(true).to.be(true);
-  			})
-  		});
+    //using a YUI use
+    YUI().use("test", function (Y) {
+  	describe('hi mocha', function(){
+  		it('should have a passing test', function(){
+  			expect(true).to.be(true);
+  		})
+  	});
 
-  		if(!("$yetify" in window)) {
-  	        var runner = mocha.run();
-  	  }
-    }, 50);
+  	if(!("$yetify" in window)) {
+  	     var runner = mocha.run();
+  	}
+    });
 	</script>
   </body>
 </html>

--- a/test/functional/fixture/mocha-async.html
+++ b/test/functional/fixture/mocha-async.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Yeti Mocha Test</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <link rel="stylesheet" href="../../../dep/dev/mocha.css" />
+    <script src="../../../dep/dev/mocha.js"></script>
+    <script src="../../../dep/dev/expect.js"></script>
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <script>
+		mocha.setup('bdd');
+    mocha.asyncYeti = true;
+
+    //simulate an async initialization of mocha
+    //using a timeout.
+    setTimeout(function(){
+  		describe('hi mocha', function(){
+  			it('should have a passing test', function(){
+  			  expect(true).to.be(true);
+  			})
+  		});
+
+  		if(!("$yetify" in window)) {
+  	        var runner = mocha.run();
+  	  }
+    }, 50);
+	</script>
+  </body>
+</html>


### PR DESCRIPTION
This addresses the following issues:
- https://github.com/yui/yeti/issues/60
- http://yuilibrary.com/forum/viewtopic.php?p=39725

Because mocha needs to be initialized (`mocha.run()`) in order to return a reference to the runner (need by Yeti to bind events), any tests that use a deferred initialization of mocha (via `requirejs.require`, `YUI.use`, or other means) will not be run correctly.

This PR addresses the issue by allowing the user to include a `asyncYeti` flag in their tests (ignored if not running Yeti).  This flag will alert Yeti to wait until the test runner defer-redly calls `mocha.run()` before initializing mocha.

It's less than ideal because it requires the creation of the flag variables, and because it overrides `mocha.run` temporarily.  However, I think these tradeoff are fair given that it works and unblocks users who are unable to use Yeti because they have deferred mocha initializations.

Mocha may or may not be updated in the future (https://github.com/visionmedia/mocha/pull/719), so I think leaving the Yeti binding patterns in place is better than trying to over-engineer a solution to this problem.

Let me know what you think!
