### PR TITLE
Return the original file when instrumentation failed

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -203,10 +203,10 @@ ClientBatch.prototype.provideTests = function () {
                 try {
                     data = data.toString("utf8");
                     data = self.instrumenter.instrumentSync(data, file);
-                    return reply(null, new Buffer(data, "utf8"));
                 } catch (err) {
-                    return reply(err);
+                    console.log("Unable to instrument file " + file + ": " + err);
                 }
+                return reply(null, new Buffer(data, "utf8"));
             };
         }
 


### PR DESCRIPTION
We've recently hit a case where some of our old JS (something I'm trying to rewrite) failed to instrument. As a result, everything depending on it failed.

Ideally if a file fails to instrument, it should still be served in it's original form and the warning logged.

I couldn't see any existing way to actually log this. It doesn't make sense to log this to the browser because we want the developer to know (and they aren't looking at a browser). For the moment I've used console.log, but happy to take advice on a better way of doing this within Yeti.
