### PR TITLE
Upgrade istanbul to ~0.2.9.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "minimatch": "~0.2.14"
   },
   "optionalDependencies": {
-    "istanbul": "~0.2.4"
+    "istanbul": "~0.2.9"
   },
   "devDependencies": {
     "mocks": ">=0.0.15",


### PR DESCRIPTION
0.2.9 includes https://github.com/gotwarlost/istanbul/issues/202 which prevents instrumentation of certain uses of the `with` syntax.
