### PR TITLE
Add support for serving files within a test directory through echoecho

### DIFF
--- a/lib/hub/index.js
+++ b/lib/hub/index.js
@@ -230,7 +230,8 @@ Hub.prototype.generateId = function () {
  */
 Hub.prototype._handleTestRequest = function (server, agentId, batchId, path) {
     var batch = this.allBatches.getBatch(batchId),
-        file = urlParser.parse(path).pathname;
+        file = urlParser.parse(path).pathname,
+        echoroot;
 
     if (!batch) {
         server.res.message(404, "Batch not found.");
@@ -241,8 +242,11 @@ Hub.prototype._handleTestRequest = function (server, agentId, batchId, path) {
                 "file =", file, "method =", server.req.method);
 
     if (this.echoecho.handle(path)) {
+        echoroot = path.split('/echo/')[0];
         this.debug("echoecho serving this request");
-        this.echoecho.serve(server.req, server.res);
+        this.echoecho.serve(server.req, server.res, {
+            dirroot: echoroot
+        });
     } else if (server.req.method !== "GET" && server.req.method !== "HEAD") {
         server.res.message(405, "GET or HEAD method required.");
     } else {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "async": "~0.2.5",
     "wd": "~0.2.5",
-    "echoecho": "~0.1.6",
+    "echoecho": "~0.1.9",
     "eventemitter2": "~0.4.8",
     "eventyoshi": "~0.1.2",
     "nopt": "~2.1.1",


### PR DESCRIPTION
In order to test valid serving of files in combination with things like:
- get
- post
- delays

Yeti needs to specify the new `dirroot` argument to echoecho so that files served. This was added in 0.1.9 of echoecho.

You can then use echoecho to retrieve URLs like `echo/delay/3/get?file=assets/checknet.txt` which are converted into URLs such as `tests/unit/moodle-core-checknet/main/echo/delay/3/get?file=assets/checknet.txt` by Yeti, and `tests/unit/moodle-core-checknet/main/assets/checknet.txt` by EchoEcho.
