### PR TITLE
This modifications fix the use of regex with glob on windows.

### DIFF
--- a/lib/blizzard/index.js
+++ b/lib/blizzard/index.js
@@ -73,7 +73,6 @@ Blizzard.prototype.createSession = function (socket, instigator) {
  * @protected
  */
 Blizzard.prototype.onClientUpgrade = function (cb, req, socket) {
-    //this.emit("connect", socket);
     cb(null, this.createSession(socket, true));
 };
 
@@ -85,9 +84,6 @@ Blizzard.prototype.onClientUpgrade = function (cb, req, socket) {
  * @protected
  */
 Blizzard.prototype.serverUpgrade = function (req, socket) {
-    // console.log("Recieved upgrade.");
-    // console.log("Headers =", req.headers);
-
     var self = this,
         version = req.headers["sec-blizzard-version"];
 

--- a/lib/hub/batch.js
+++ b/lib/hub/batch.js
@@ -9,6 +9,7 @@ var TestSpecification = require("./test-specification");
 var TestServer = require("./http/test-server");
 
 var WebDriverCollection = require("./webdriver-collection");
+var path = require('path');
 
 /**
  * A Batch represents a collection of tests on the Hub.
@@ -319,7 +320,7 @@ Batch.prototype.handleFileRequest = function (server, agentId, filename) {
     }
 
     fileInBatch = batch.spec.tests.some(function (test) {
-        return test === filename;
+        return path.normalize(test) === path.normalize(filename);
     });
 
     this.getFile(filename, function (err, buffer) {

--- a/lib/hub/batch.js
+++ b/lib/hub/batch.js
@@ -9,7 +9,7 @@ var TestSpecification = require("./test-specification");
 var TestServer = require("./http/test-server");
 
 var WebDriverCollection = require("./webdriver-collection");
-var path = require('path');
+var path = require("path");
 
 /**
  * A Batch represents a collection of tests on the Hub.

--- a/lib/hub/index.js
+++ b/lib/hub/index.js
@@ -97,7 +97,7 @@ var Hub = module.exports = function Hub(options) {
 
     this._setupEvents();
 
-    this.mountpoint = "/";
+    this.mountpoint = '/';
 
     this.webdriver = options.webdriver;
 };
@@ -271,7 +271,6 @@ Hub.prototype._onTowerConnection = function (socket) {
 
     client.on("register", function (message) {
         var id = message.agentId;
-
         if (!id || id === "undefined") {
             client.emit("error", "ID required");
         }

--- a/lib/hub/index.js
+++ b/lib/hub/index.js
@@ -97,7 +97,7 @@ var Hub = module.exports = function Hub(options) {
 
     this._setupEvents();
 
-    this.mountpoint = '/';
+    this.mountpoint = "/";
 
     this.webdriver = options.webdriver;
 };

--- a/lib/hub/null-test.js
+++ b/lib/hub/null-test.js
@@ -7,7 +7,7 @@
 var util = require("util");
 
 var Test = require("./test");
-var path = require('path');
+var path = require("path");
 
 /**
  * NullTest represents the absence of a Test.

--- a/lib/hub/null-test.js
+++ b/lib/hub/null-test.js
@@ -7,6 +7,7 @@
 var util = require("util");
 
 var Test = require("./test");
+var path = require('path');
 
 /**
  * NullTest represents the absence of a Test.
@@ -34,7 +35,7 @@ util.inherits(NullTest, Test);
  * @return {String} Relative URL for the capture page, relative to the mountpoint.
  */
 NullTest.prototype.getUrlForAgentId = function (agentId) {
-    return this.mountpoint + "agent/" + agentId;
+    return this.mountpoint + "agent" + path.sep + agentId;
 };
 
 /**

--- a/lib/hub/test.js
+++ b/lib/hub/test.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var path = require('path');
 /**
  * @module test
  */
@@ -34,9 +35,9 @@ function Test(options) {
  */
 Test.prototype.getUrlForAgentId = function (agentId) {
     var url = this.mountpoint;
-    url += "agent/" + agentId;
-    url += "/batch/" + this.batchId;
-    url += "/test/" + this.location;
+    url += "agent" + path.sep + agentId;
+    url += path.sep + "batch" + path.sep + this.batchId;
+    url += path.sep + "test" + path.sep + this.location;
     if (this.query) { url += "?" + this.query; }
     return url;
 };

--- a/lib/hub/test.js
+++ b/lib/hub/test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var path = require('path');
+var path = require("path");
 /**
  * @module test
  */

--- a/lib/hub/tests.js
+++ b/lib/hub/tests.js
@@ -7,7 +7,7 @@
 var Test = require("./test");
 var LiteralTest = require("./literal-test");
 var NullTest = require("./null-test");
-var path = require('path');
+var path = require("path");
 
 /**
  * Tests represent a collection of Test objects.

--- a/lib/hub/tests.js
+++ b/lib/hub/tests.js
@@ -7,6 +7,7 @@
 var Test = require("./test");
 var LiteralTest = require("./literal-test");
 var NullTest = require("./null-test");
+var path = require('path');
 
 /**
  * Tests represent a collection of Test objects.
@@ -47,9 +48,9 @@ Tests.prototype.getByUrl = function (url) {
         location;
 
     for (; index < length; index += 1) {
-        location = locations[index];
+        location = path.normalize(locations[index]);
 
-        if (url.indexOf(location) !== -1) {
+        if (path.normalize(url).indexOf(location) !== -1) {
             return this.children[location];
         }
     }
@@ -114,7 +115,6 @@ Tests.prototype.initializeFromSpecification = function (spec) {
             options.query = spec.query;
             options.mountpoint = self.mountpoint;
         }
-
         self.children[location] = new TestCtor(options);
     });
 };

--- a/lib/hub/url-builder.js
+++ b/lib/hub/url-builder.js
@@ -1,20 +1,22 @@
 "use strict";
 
+var path = require('path');
+
 module.exports = function makeURLFromComponents(mountpoint, agentId, batchId, test) {
     var url = mountpoint;
 
-    if (url !== "/") {
+    if (url !== path.sep) {
         // XXX So hacky.
-        url += "/";
+        url += path.sep;
     }
 
-    url += "agent/" + agentId;
+    url += "agent" + path.sep + agentId;
 
     if (test && batchId) {
         // XXX if test is true,
         // batchId should always be set
-        url += "/batch/" + batchId;
-        url += "/test/" + test;
+        url += path.sep + "batch" + path.sep + batchId;
+        url += path.sep + "test" + path.sep + test;
     }
 
     return url;

--- a/lib/hub/url-builder.js
+++ b/lib/hub/url-builder.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var path = require('path');
+var path = require("path");
 
 module.exports = function makeURLFromComponents(mountpoint, agentId, batchId, test) {
     var url = mountpoint;


### PR DESCRIPTION
Getting the test by URL and finding the base file of the test to inject inject.js were done using the path as string. Since windows uses '\' instead of '/' the script was never injected.
